### PR TITLE
7-display-the-articles-in-descending-order-of-publication-date

### DIFF
--- a/src/pages/__tests__/blog.test.ts
+++ b/src/pages/__tests__/blog.test.ts
@@ -19,14 +19,15 @@ describe('ブログ機能', () => {
 
   it('ブログ詳細ページが記事をslugで取得する', () => {
     const detailPage = load('../blog/[slug].astro');
-    expect(detailPage).toContain("getEntryBySlug('blog'");
+    expect(detailPage).toContain("getCollection('blog'");
+    expect(detailPage).toMatch(/posts\.find\(\(post\) => post\.slug === slug\)/);
     expect(detailPage).toContain('Astro.params.slug');
   });
 
-  it('ブログ一覧はdraft記事を除外する', () => {
+  it('ブログ一覧は公開済み記事を降順で取得する', () => {
     const index = load('../blog/index.astro');
-    expect(index).toContain('filter((post)');
-    expect(index).toContain('!post.data.draft');
+    expect(index).toContain('sortPublishedPostsByDate');
+    expect(index).toContain('const sortedPosts = sortPublishedPostsByDate(blogPosts);');
   });
 
   it('ブログ一覧のリード文が日本語で案内されている', () => {

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,7 +1,8 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import Link from '../../components/Link.astro';
-import { getCollection, getEntryBySlug } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => !data.draft);
@@ -12,9 +13,12 @@ export async function getStaticPaths() {
 }
 
 const slug = Astro.params.slug;
-const entry = slug ? await getEntryBySlug('blog', slug) : null;
+const posts = await getCollection('blog', ({ data }) => !data.draft);
+const entry = slug
+  ? (posts.find((post) => post.slug === slug) as CollectionEntry<'blog'> | undefined)
+  : undefined;
 
-if (!entry || entry.data.draft) {
+if (!entry) {
   throw new Response(null, { status: 404 });
 }
 
@@ -62,7 +66,7 @@ const heroClass = heroImage
 
             {tags && (
               <div class="tag-list" aria-label="Tags">
-                {tags.map((tag) => (
+                {tags.map((tag: string) => (
                   <span class="tag">{tag}</span>
                 ))}
               </div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,12 +2,10 @@
 import Layout from '../../layouts/Layout.astro';
 import Link from '../../components/Link.astro';
 import { getCollection } from 'astro:content';
+import { sortPublishedPostsByDate } from '../../utils/blog';
 
 const blogPosts = await getCollection('blog');
-const publishedPosts = blogPosts.filter((post) => !post.data.draft);
-const sortedPosts = publishedPosts.sort(
-  (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime()
-);
+const sortedPosts = sortPublishedPostsByDate(blogPosts);
 ---
 
 <Layout title="Blog - Portfolio">

--- a/src/utils/__tests__/blog-sort.test.ts
+++ b/src/utils/__tests__/blog-sort.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CollectionEntry } from 'astro:content';
+import { sortPublishedPostsByDate } from '../blog';
+
+const buildPost = (
+  slug: string,
+  pubDate: string,
+  draft = false
+): CollectionEntry<'blog'> =>
+  ({
+    slug,
+    data: {
+      title: slug,
+      description: '',
+      pubDate: new Date(pubDate),
+      draft,
+    },
+  } as unknown as CollectionEntry<'blog'>);
+
+describe('sortPublishedPostsByDate', () => {
+  it('draftを除外し、公開日の降順で並べ替える', () => {
+    const posts = [
+      buildPost('first', '2024-01-10'),
+      buildPost('latest', '2024-02-01'),
+      buildPost('draft-post', '2025-03-01', true),
+    ];
+
+    const sorted = sortPublishedPostsByDate(posts);
+
+    expect(sorted.map((post) => post.slug)).toEqual(['latest', 'first']);
+  });
+});

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -1,0 +1,8 @@
+import type { CollectionEntry } from 'astro:content';
+
+export const sortPublishedPostsByDate = (
+  posts: CollectionEntry<'blog'>[]
+): CollectionEntry<'blog'>[] =>
+  posts
+    .filter((post) => !post.data.draft)
+    .sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime());


### PR DESCRIPTION
## 目的
ブログ一覧が公開日の降順で表示されるようにし、draftを除外した取得ロジックに合わせてテストを更新する。

## 変更内容
- 公開済み記事を降順ソートするユーティリティ `sortPublishedPostsByDate` を追加し、ブログ一覧で利用
- 詳細ページを `getCollection` + `find` で取得する型安全な実装にリファクタ
- ブログ一覧・詳細のテストを新ロジックに合わせて更新
- ソート処理のユニットテストを追加

## テスト
- `npm test`
- `npm run check`
- `npm run build`
