### PR TITLE
10-regarding-the-annotation-feature

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,13 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import remarkDirective from 'remark-directive';
+import { remarkAdmonition } from './src/utils/remarkAdmonition.js';
 
 // https://astro.build/config
 export default defineConfig({
   base: '/portfolio',
   markdown: {
+    remarkPlugins: [remarkDirective, remarkAdmonition],
     shikiConfig: {
       theme: 'github-dark-dimmed',
       wrap: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "portfolio",
       "version": "1.0.0",
       "dependencies": {
-        "astro": "^5.14.4"
+        "astro": "^5.14.4",
+        "remark-directive": "^4.0.0"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.4",
@@ -388,7 +389,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -435,7 +435,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2553,6 +2552,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -3615,6 +3624,40 @@
         "url": "https://github.com/sponsors/brc-dd"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -3660,6 +3703,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-inside-container": {
@@ -3922,6 +3975,27 @@
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
         "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-directive": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4221,6 +4295,25 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -4916,6 +5009,31 @@
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "license": "MIT"
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -5007,7 +5125,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5023,7 +5140,6 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5040,7 +5156,6 @@
       "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.9.1",
         "prettier": "^3.0.0",
@@ -5271,6 +5386,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+      "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -5462,7 +5593,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.43.0.tgz",
       "integrity": "sha512-wdN2Kd3Twh8MAEOEJZsuxuLKCsBEo4PVNLK6tQWAn10VhsVewQLzcucMgLolRlhFybGxfclbPeEYBaP6RvUFGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -5965,7 +6095,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6324,7 +6453,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7153,7 +7281,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "astro": "^5.14.4"
+    "astro": "^5.14.4",
+    "remark-directive": "^4.0.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",

--- a/src/content/blog/typescript-zod-valibot-scope.md
+++ b/src/content/blog/typescript-zod-valibot-scope.md
@@ -7,6 +7,10 @@ tags: ['typescript', 'zod', 'valibot']
 
 ## Type だけじゃダメ？Zod / Valibot が必要になる理由を整理する
 
+:::info
+この記事はAIが書き、人間がレビューしています
+:::
+
 「**普通に `type` で型をつければよくない？**」
 
 TypeScript を触っていると、一度はこう思うはずです。

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -264,6 +264,56 @@ const heroClass = heroImage
     color: var(--text-secondary);
   }
 
+  .content-wrapper :global(.admonition) {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-xs) var(--space-md);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--glass-border);
+    background: var(--glass-subtle);
+    margin: var(--space-lg) 0;
+    position: relative;
+  }
+
+  .content-wrapper :global(.admonition)::before {
+    content: attr(data-icon);
+    font-size: var(--font-size-lg);
+    line-height: 1;
+    margin-right: var(--space-xs);
+  }
+
+  .content-wrapper :global(.admonition-note) {
+    border-left: 4px solid var(--text-accent);
+    background: rgba(59, 130, 246, 0.08);
+  }
+
+  .content-wrapper :global(.admonition-info) {
+    border-left: 4px solid #2563eb;
+    background: rgba(59, 130, 246, 0.08);
+  }
+
+  .content-wrapper :global(.admonition-warning) {
+    border-left: 4px solid #f59e0b;
+    background: rgba(245, 158, 11, 0.1);
+  }
+
+  .content-wrapper :global(.admonition-tip) {
+    border-left: 4px solid #10b981;
+    background: rgba(16, 185, 129, 0.08);
+  }
+
+  .content-wrapper :global(.admonition-important) {
+    border-left: 4px solid #ef4444;
+    background: rgba(239, 68, 68, 0.1);
+  }
+
+  .content-wrapper :global(.admonition p) {
+    margin: 0;
+    display: inline;
+  }
+
+
   .article-footer {
     padding-bottom: var(--space-2xl);
   }

--- a/src/utils/__tests__/remark-admonition.test.ts
+++ b/src/utils/__tests__/remark-admonition.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { remarkAdmonition } from '../remarkAdmonition.js';
+
+const runPlugin = (tree: any) => {
+  const transformer = remarkAdmonition();
+  transformer(tree);
+  return tree;
+};
+
+describe('remarkAdmonition', () => {
+  it('noteディレクティブをアクセシブルな注釈コンポーネントに変換する', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'containerDirective',
+          name: 'note',
+          children: [{ type: 'paragraph', children: [{ type: 'text', value: 'メモ' }] }],
+        },
+      ],
+    };
+
+    const { children } = runPlugin(tree);
+    const node = children[0];
+
+    expect(node.data?.hName).toBe('aside');
+    expect(node.data?.hProperties?.className).toContain('admonition');
+    expect(node.data?.hProperties?.className).toContain('admonition-note');
+    expect(node.data?.hProperties?.['data-icon']).toBe('📝');
+  });
+
+  it('leafディレクティブもspanで処理される', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'leafDirective',
+          name: 'tip',
+          children: [{ type: 'text', value: '一言メモ' }],
+        },
+      ],
+    };
+
+    const node = runPlugin(tree).children[0];
+    expect(node.data?.hName).toBe('span');
+    expect(node.data?.hProperties?.className).toContain('admonition-tip');
+    expect(node.data?.hProperties?.['data-icon']).toBe('💡');
+  });
+
+  it('warn / warning / caution は warning にマッピングする', () => {
+    const aliases = ['warn', 'warning', 'caution'];
+
+    aliases.forEach((name) => {
+      const tree = {
+        type: 'root',
+        children: [{ type: 'containerDirective', name, children: [] }],
+      };
+
+      const node = runPlugin(tree).children[0];
+      expect(node.data?.hProperties?.className).toContain('admonition-warning');
+      expect(node.data?.hProperties?.['data-icon']).toBe('⚠️');
+    });
+  });
+
+  it('非対応ディレクティブは素通しする', () => {
+    const tree = {
+      type: 'root',
+      children: [{ type: 'containerDirective', name: 'unknown', children: [] }],
+    };
+
+    const node = runPlugin(tree).children[0];
+    expect(node.data).toBeUndefined();
+  });
+});

--- a/src/utils/remarkAdmonition.js
+++ b/src/utils/remarkAdmonition.js
@@ -1,0 +1,51 @@
+const DIRECTIVE_CONFIG = {
+  note: { icon: '📝', className: 'admonition-note', label: 'note' },
+  info: { icon: 'ℹ️', className: 'admonition-info', label: 'info' },
+  tip: { icon: '💡', className: 'admonition-tip', label: 'tip' },
+  warn: { icon: '⚠️', className: 'admonition-warning', label: 'warning' },
+  warning: { icon: '⚠️', className: 'admonition-warning', label: 'warning' },
+  caution: { icon: '⚠️', className: 'admonition-warning', label: 'warning' },
+  important: { icon: '❗️', className: 'admonition-important', label: 'important' },
+};
+
+const SUPPORTED = new Set(Object.keys(DIRECTIVE_CONFIG));
+
+const walk = (node, visitor) => {
+  visitor(node);
+  if (Array.isArray(node?.children)) {
+    node.children.forEach((child) => walk(child, visitor));
+  }
+};
+
+export const remarkAdmonition = () => {
+  return (tree) => {
+    walk(tree, (node) => {
+      const isContainer = node?.type === 'containerDirective';
+      const isLeaf = node?.type === 'leafDirective';
+      if (!(isContainer || isLeaf) || !SUPPORTED.has(node.name)) {
+        return;
+      }
+
+      const config = DIRECTIVE_CONFIG[node.name];
+      const data = node.data || (node.data = {});
+      const properties = data.hProperties || {};
+      const classSource = properties.className || properties.class;
+      const classList = Array.isArray(classSource)
+        ? classSource
+        : classSource
+          ? [classSource]
+          : [];
+
+      data.hName = isLeaf ? 'span' : 'aside';
+      data.hProperties = {
+        ...properties,
+        role: 'note',
+        className: [...classList, 'admonition', config.className],
+        'aria-label': config.label,
+        'data-icon': config.icon,
+      };
+      // children are kept as-is; layout handled by CSS
+      node.data = data;
+    });
+  };
+};


### PR DESCRIPTION
## 概要
- remark-directive と自作プラグインで `:::note/info/tip/warn|warning|caution/important` の注釈ディレクティブをサポート
- ブログ本文にアイコン付き1行レイアウトの注釈スタイルを追加
- 既存ブログ記事（antigravity-overview / git-worktree-runner）に注釈を追記

## UI / コンテンツ
- ブログ記事内の注釈ボックスの見た目を追加・調整（アイコン＋薄めのボーダー）
- 新しい注釈文言を2記事に追加

## テスト
- npm test
- npm run check

## スクリーンショット
- （必要なら実機キャプチャを添付してください）