### PR TITLE
fix: keep footer on single line on mobile

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -273,13 +273,15 @@ const navItems = baseNavItems.map((item) => {
       text-align: center;
     }
 
-    .footer-content span,
-    .social-links {
-      white-space: nowrap;
-    }
-
     main {
       margin-top: 120px;
+    }
+  }
+
+  @media (max-width: 360px) {
+    .footer-content {
+      flex-wrap: wrap;
+      row-gap: var(--space-xs);
     }
   }
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -267,9 +267,15 @@ const navItems = baseNavItems.map((item) => {
     }
 
     .footer-content {
-      flex-direction: column;
-      gap: var(--space-md);
+      justify-content: center;
+      flex-wrap: nowrap;
+      gap: var(--space-sm);
       text-align: center;
+    }
+
+    .footer-content span,
+    .social-links {
+      white-space: nowrap;
     }
 
     main {


### PR DESCRIPTION
### Motivation
- Prevent the footer from wrapping into two rows on narrow viewports so copyright and social links stay on one line.

### Description
- Updated mobile footer CSS in `src/layouts/Layout.astro` to remove the column layout and apply `justify-content: center`, `flex-wrap: nowrap`, and reduced `gap` for the `.footer-content` at `@media (max-width: 768px)`.
- Added `white-space: nowrap` to the footer text and `.social-links` so the elements do not break onto multiple lines.

### Testing
- Ran unit tests with `npm test -- --run` (Vitest) and all tests passed.
- Ran `npm run check` which failed in this environment due to missing `astro:content` type declarations (environment issue, not related to the CSS change).
- Started the dev server and captured a mobile viewport screenshot via Playwright to verify the footer visually, which produced `artifacts/footer-mobile.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aba2bf98f48322a3e2e55691d3c692)