### PR TITLE
[codex] add agent-readable portfolio tools

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,15 +1,30 @@
+
+
 # list of languages for which language servers are started; choose from:
-#   al               bash             clojure          cpp              csharp           csharp_omnisharp
-#   dart             elixir           elm              erlang           fortran          go
-#   haskell          java             julia            kotlin           lua              markdown
-#   nix              perl             php              python           python_jedi      r
-#   rego             ruby             ruby_solargraph  rust             scala            swift
-#   terraform        typescript       typescript_vts   yaml             zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
-#   - csharp: Requires the presence of a .sln file in the project folder.
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
 # When using multiple languages, the first language server that supports a given file will be used for that file.
 # The first language is the default language and the respective language server will be used as a fallback.
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
@@ -20,14 +35,12 @@ languages:
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
 encoding: "utf-8"
 
-# whether to use the project's gitignore file to ignore files
-# Added on 2025-04-07
+# whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 
-# list of additional paths to ignore
-# same syntax as gitignore, so you can use * and **
-# Was previously called `ignored_dirs`, please update your config if you are using that.
-# Added (renamed) on 2025-04-07
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
 # whether the project is in read-only mode
@@ -35,45 +48,9 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -82,7 +59,9 @@ initial_prompt: ""
 # the name by which the project can be referenced within Serena
 project_name: "blog"
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -93,13 +72,69 @@ included_optional_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -98,6 +98,9 @@ const navItems = baseNavItems.map((item) => {
         </div>
       </div>
     </footer>
+    <script>
+      import '../scripts/portfolio-webmcp';
+    </script>
     <script is:inline>
       const normalizePathname = (input) => {
         if (!input || input === '/') {

--- a/src/pages/agent-index.json.ts
+++ b/src/pages/agent-index.json.ts
@@ -1,0 +1,99 @@
+import { getCollection, getEntry, type CollectionEntry } from 'astro:content';
+import type { APIRoute } from 'astro';
+
+import { sortPublishedPostsByDate } from '../utils/blog';
+import type {
+  AgentBlogPost,
+  AgentIndex,
+  AgentProject,
+} from '../utils/agentTypes';
+import { withBase } from '../utils/withBase';
+
+export const prerender = true;
+
+const githubUrl =
+  import.meta.env.PUBLIC_GITHUB_URL || 'https://github.com/penpenguin';
+const email = import.meta.env.PUBLIC_EMAIL || null;
+
+export const GET: APIRoute = async () => {
+  const [projects, blogPosts, careerEntry] = await Promise.all([
+    getCollection('projects'),
+    getCollection('blog'),
+    getEntry('career', 'career'),
+  ]);
+
+  if (!careerEntry) {
+    throw new Error(
+      'Missing career content entry: src/content/pages/career.md'
+    );
+  }
+
+  const agentIndex: AgentIndex = {
+    site: {
+      name: 'Portfolio',
+      url: new URL(withBase('/'), 'https://penpenguin.github.io').toString(),
+      description: 'Modern portfolio built with Astro',
+    },
+    profile: {
+      headline: 'メーカーの社内システム構築支援に強いフルスタックプログラマー',
+      skills: [
+        'Java',
+        'TypeScript',
+        'React',
+        'Azure',
+        'Quarkus',
+        'Node.js',
+        'PostgreSQL',
+        'ArangoDB',
+        'GitLab CI/CD',
+      ],
+      experience: '10+ years',
+      specialties: [
+        'Enterprise Systems',
+        'Full-stack Web Development',
+        'Cloud Infrastructure',
+        'CI/CD Automation',
+        'Team Leadership',
+      ],
+    },
+    projects: projects.map(toAgentProject),
+    blog: sortPublishedPostsByDate(blogPosts).map(toAgentBlogPost),
+    career: careerEntry.data.timeline,
+    contact: {
+      pageUrl: withBase('/contact'),
+      githubUrl,
+      email,
+    },
+  };
+
+  return new Response(JSON.stringify(agentIndex, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  });
+};
+
+const toAgentProject = (
+  project: CollectionEntry<'projects'>
+): AgentProject => ({
+  type: 'project',
+  id: project.slug,
+  title: project.data.title,
+  description: project.data.description,
+  pubDate: project.data.pubDate.toISOString(),
+  tags: project.data.tags ?? [],
+  url: withBase(`/projects/${project.slug}`),
+  liveUrl: project.data.link ?? null,
+  githubUrl: project.data.github ?? null,
+});
+
+const toAgentBlogPost = (post: CollectionEntry<'blog'>): AgentBlogPost => ({
+  type: 'blog',
+  id: post.id,
+  title: post.data.title,
+  description: post.data.description,
+  pubDate: post.data.pubDate.toISOString(),
+  updatedDate: post.data.updatedDate?.toISOString() ?? null,
+  tags: post.data.tags ?? [],
+  url: withBase(`/blog/${post.id}`),
+});

--- a/src/scripts/portfolio-webmcp.test.ts
+++ b/src/scripts/portfolio-webmcp.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createPortfolioTools,
   isSafePortfolioUrl,
-  registerTool,
+  registerTool as registerToolAdapter,
   type AgentIndex,
 } from './portfolio-webmcp';
 
@@ -54,14 +54,61 @@ const index: AgentIndex = {
 };
 
 beforeEach(() => {
+  vi.restoreAllMocks();
+  delete window.webMCP;
+  delete navigator.webMCP;
+  delete navigator.modelContext;
   delete window.__portfolioTools;
 });
 
 describe('registerTool', () => {
+  it('navigator.modelContextがある場合はexecuteに変換して標準registryへ登録する', async () => {
+    const invoke = vi.fn().mockReturnValue('ok');
+    const registerTool = vi.fn();
+    Object.defineProperty(navigator, 'modelContext', {
+      configurable: true,
+      value: {
+        registerTool,
+      },
+    });
+
+    await registerToolAdapter({
+      name: 'portfolio.test',
+      title: 'Test tool',
+      description: 'Test description',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+      annotations: {
+        readOnlyHint: true,
+      },
+      invoke,
+    });
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    const [tool] = registerTool.mock.calls[0];
+    expect(tool).toMatchObject({
+      name: 'portfolio.test',
+      title: 'Test tool',
+      description: 'Test description',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+      },
+      annotations: {
+        readOnlyHint: true,
+      },
+    });
+    expect(tool.execute({ query: 'PWA' })).toBe('ok');
+    expect(invoke).toHaveBeenCalledWith({ query: 'PWA' });
+    expect(window.__portfolioTools).toBeUndefined();
+  });
+
   it('WebMCPがない場合はwindow.__portfolioToolsにfallback登録する', async () => {
     const invoke = vi.fn();
 
-    await registerTool({ name: 'portfolio.test', invoke });
+    await registerToolAdapter({ name: 'portfolio.test', invoke });
 
     expect(window.__portfolioTools?.['portfolio.test']).toBe(invoke);
   });

--- a/src/scripts/portfolio-webmcp.test.ts
+++ b/src/scripts/portfolio-webmcp.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createPortfolioTools,
+  isSafePortfolioUrl,
+  registerTool,
+  type AgentIndex,
+} from './portfolio-webmcp';
+
+const index: AgentIndex = {
+  site: {
+    name: 'Portfolio',
+    url: 'https://penpenguin.github.io/portfolio/',
+    description: 'Modern portfolio built with Astro',
+  },
+  profile: {
+    headline: 'Programmer',
+    skills: ['TypeScript'],
+    experience: '10+ years',
+    specialties: ['Enterprise Systems'],
+  },
+  projects: [
+    {
+      type: 'project',
+      id: 'todo-pwa',
+      title: 'Offline Todo Progressive Web App',
+      description: 'オフライン対応のタスク管理PWA',
+      pubDate: '2024-01-15T00:00:00.000Z',
+      tags: ['PWA'],
+      url: '/portfolio/projects/todo-pwa',
+      liveUrl: 'https://penpenguin.github.io/todo-pwa/',
+      githubUrl: 'https://github.com/penpenguin/todo-pwa',
+    },
+  ],
+  blog: [
+    {
+      type: 'blog',
+      id: '2026/05/webmcp-basics',
+      title: 'WebMCP basics',
+      description: 'ブラウザ内AIエージェント向けの記事',
+      pubDate: '2026-05-01T00:00:00.000Z',
+      updatedDate: null,
+      tags: ['WebMCP'],
+      url: '/portfolio/blog/2026/05/webmcp-basics',
+    },
+  ],
+  career: [],
+  contact: {
+    pageUrl: '/portfolio/contact',
+    githubUrl: 'https://github.com/penpenguin',
+    email: null,
+  },
+};
+
+beforeEach(() => {
+  delete window.__portfolioTools;
+});
+
+describe('registerTool', () => {
+  it('WebMCPがない場合はwindow.__portfolioToolsにfallback登録する', async () => {
+    const invoke = vi.fn();
+
+    await registerTool({ name: 'portfolio.test', invoke });
+
+    expect(window.__portfolioTools?.['portfolio.test']).toBe(invoke);
+  });
+});
+
+describe('createPortfolioTools', () => {
+  it('portfolio.search_contentでprojectsとblogを横断検索する', async () => {
+    const tools = createPortfolioTools(index);
+    const searchContent = tools.find(
+      (tool) => tool.name === 'portfolio.search_content'
+    );
+
+    await expect(
+      Promise.resolve(
+        searchContent?.invoke({ query: 'PWA', type: 'all', limit: 5 })
+      )
+    ).resolves.toEqual([index.projects[0]]);
+  });
+
+  it('portfolio.get_contact_routesで連絡先を返す', async () => {
+    const tools = createPortfolioTools(index);
+    const getContactRoutes = tools.find(
+      (tool) => tool.name === 'portfolio.get_contact_routes'
+    );
+
+    await expect(
+      Promise.resolve(getContactRoutes?.invoke({}))
+    ).resolves.toEqual(index.contact);
+  });
+});
+
+describe('isSafePortfolioUrl', () => {
+  it('同一originかつportfolio配下のURLだけ許可する', () => {
+    expect(
+      isSafePortfolioUrl('/portfolio/projects', window.location, '/portfolio/')
+    ).toBe(true);
+    expect(isSafePortfolioUrl('/about', window.location, '/portfolio/')).toBe(
+      false
+    );
+    expect(
+      isSafePortfolioUrl('https://example.com/', window.location, '/portfolio/')
+    ).toBe(false);
+    expect(
+      isSafePortfolioUrl('javascript:alert(1)', window.location, '/portfolio/')
+    ).toBe(false);
+  });
+});

--- a/src/scripts/portfolio-webmcp.ts
+++ b/src/scripts/portfolio-webmcp.ts
@@ -40,6 +40,19 @@ interface WebMCPRegistry {
   registerTool: (tool: ToolDefinition) => void | Promise<void>;
 }
 
+interface ModelContextTool {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  annotations?: ToolDefinition['annotations'];
+  execute: (input: unknown, client?: unknown) => unknown | Promise<unknown>;
+}
+
+interface ModelContextRegistry {
+  registerTool: (tool: ModelContextTool) => void | Promise<void>;
+}
+
 declare global {
   interface Window {
     webMCP?: WebMCPRegistry;
@@ -47,6 +60,7 @@ declare global {
   }
 
   interface Navigator {
+    modelContext?: ModelContextRegistry;
     webMCP?: WebMCPRegistry;
   }
 }
@@ -54,6 +68,11 @@ declare global {
 let registrationPromise: Promise<void> | null = null;
 
 export async function registerTool(tool: ToolDefinition): Promise<void> {
+  if (navigator.modelContext?.registerTool) {
+    await navigator.modelContext.registerTool(toModelContextTool(tool));
+    return;
+  }
+
   const webMCP = window.webMCP ?? navigator.webMCP;
 
   if (webMCP?.registerTool) {
@@ -65,13 +84,29 @@ export async function registerTool(tool: ToolDefinition): Promise<void> {
   window.__portfolioTools[tool.name] = tool.invoke;
 }
 
+function toModelContextTool(tool: ToolDefinition): ModelContextTool {
+  return {
+    name: tool.name,
+    title: tool.title,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    annotations: tool.annotations,
+    execute: (input: unknown) => tool.invoke(input),
+  };
+}
+
 export function createPortfolioTools(
   index: AgentIndex
 ): ToolDefinition<unknown, unknown>[] {
   return [
     {
       name: 'portfolio.search_content',
+      title: 'Search portfolio content',
       description: 'Search portfolio projects and blog posts.',
+      inputSchema: searchContentInputSchema,
+      annotations: {
+        readOnlyHint: true,
+      },
       invoke: (input: unknown) => {
         const { query, type, limit } = parseSearchContentInput(input);
         const items = [
@@ -84,7 +119,12 @@ export function createPortfolioTools(
     },
     {
       name: 'portfolio.find_projects',
+      title: 'Find portfolio projects',
       description: 'Search portfolio projects.',
+      inputSchema: searchInputSchema,
+      annotations: {
+        readOnlyHint: true,
+      },
       invoke: (input: unknown) => {
         const { query, limit } = parseSearchInput(input);
         return searchAgentItems(index.projects, query, limit);
@@ -92,7 +132,12 @@ export function createPortfolioTools(
     },
     {
       name: 'portfolio.find_blog_posts',
+      title: 'Find portfolio blog posts',
       description: 'Search portfolio blog posts.',
+      inputSchema: searchInputSchema,
+      annotations: {
+        readOnlyHint: true,
+      },
       invoke: (input: unknown) => {
         const { query, limit } = parseSearchInput(input);
         return searchAgentItems(index.blog, query, limit);
@@ -100,7 +145,12 @@ export function createPortfolioTools(
     },
     {
       name: 'portfolio.get_career_summary',
+      title: 'Get career summary',
       description: 'Return the career timeline and a short suggested summary.',
+      inputSchema: emptyInputSchema,
+      annotations: {
+        readOnlyHint: true,
+      },
       invoke: (): CareerSummaryOutput => ({
         career: index.career,
         suggestedSummary:
@@ -109,12 +159,22 @@ export function createPortfolioTools(
     },
     {
       name: 'portfolio.get_contact_routes',
+      title: 'Get contact routes',
       description: 'Return contact page, GitHub, and email routes.',
+      inputSchema: emptyInputSchema,
+      annotations: {
+        readOnlyHint: true,
+      },
       invoke: (): AgentContact => index.contact,
     },
     {
       name: 'portfolio.open_page',
+      title: 'Open portfolio page',
       description: 'Navigate to an internal portfolio page on the same origin.',
+      inputSchema: openPageInputSchema,
+      annotations: {
+        readOnlyHint: false,
+      },
       invoke: (input: unknown): OpenPageOutput => {
         const { url } = parseOpenPageInput(input);
         return openPortfolioPage(url);
@@ -122,6 +182,59 @@ export function createPortfolioTools(
     },
   ];
 }
+
+const emptyInputSchema = {
+  type: 'object',
+  properties: {},
+  additionalProperties: false,
+};
+
+const searchInputSchema = {
+  type: 'object',
+  properties: {
+    query: {
+      type: 'string',
+    },
+    limit: {
+      type: 'number',
+      minimum: 1,
+      maximum: 20,
+    },
+  },
+  required: ['query'],
+  additionalProperties: false,
+};
+
+const searchContentInputSchema = {
+  type: 'object',
+  properties: {
+    query: {
+      type: 'string',
+    },
+    type: {
+      type: 'string',
+      enum: ['all', 'project', 'blog'],
+    },
+    limit: {
+      type: 'number',
+      minimum: 1,
+      maximum: 20,
+    },
+  },
+  required: ['query'],
+  additionalProperties: false,
+};
+
+const openPageInputSchema = {
+  type: 'object',
+  properties: {
+    url: {
+      type: 'string',
+    },
+  },
+  required: ['url'],
+  additionalProperties: false,
+};
 
 export function isSafePortfolioUrl(
   url: string,

--- a/src/scripts/portfolio-webmcp.ts
+++ b/src/scripts/portfolio-webmcp.ts
@@ -1,0 +1,254 @@
+import { searchAgentItems } from '../utils/agentSearch';
+import type {
+  AgentContact,
+  AgentIndex,
+  ToolDefinition,
+} from '../utils/agentTypes';
+import { withBase } from '../utils/withBase';
+
+export type { AgentIndex, ToolDefinition } from '../utils/agentTypes';
+
+type PortfolioSearchType = 'all' | 'project' | 'blog';
+
+interface SearchContentInput {
+  query: string;
+  type?: PortfolioSearchType;
+  limit?: number;
+}
+
+interface SearchInput {
+  query: string;
+  limit?: number;
+}
+
+interface OpenPageInput {
+  url: string;
+}
+
+interface OpenPageOutput {
+  navigatedTo: string;
+}
+
+interface CareerSummaryOutput {
+  career: AgentIndex['career'];
+  suggestedSummary: string;
+}
+
+type PortfolioToolsRegistry = Record<string, ToolDefinition['invoke']>;
+
+interface WebMCPRegistry {
+  registerTool: (tool: ToolDefinition) => void | Promise<void>;
+}
+
+declare global {
+  interface Window {
+    webMCP?: WebMCPRegistry;
+    __portfolioTools?: PortfolioToolsRegistry;
+  }
+
+  interface Navigator {
+    webMCP?: WebMCPRegistry;
+  }
+}
+
+let registrationPromise: Promise<void> | null = null;
+
+export async function registerTool(tool: ToolDefinition): Promise<void> {
+  const webMCP = window.webMCP ?? navigator.webMCP;
+
+  if (webMCP?.registerTool) {
+    await webMCP.registerTool(tool);
+    return;
+  }
+
+  window.__portfolioTools ??= {};
+  window.__portfolioTools[tool.name] = tool.invoke;
+}
+
+export function createPortfolioTools(
+  index: AgentIndex
+): ToolDefinition<unknown, unknown>[] {
+  return [
+    {
+      name: 'portfolio.search_content',
+      description: 'Search portfolio projects and blog posts.',
+      invoke: (input: unknown) => {
+        const { query, type, limit } = parseSearchContentInput(input);
+        const items = [
+          ...(type === 'blog' ? [] : index.projects),
+          ...(type === 'project' ? [] : index.blog),
+        ];
+
+        return searchAgentItems(items, query, limit);
+      },
+    },
+    {
+      name: 'portfolio.find_projects',
+      description: 'Search portfolio projects.',
+      invoke: (input: unknown) => {
+        const { query, limit } = parseSearchInput(input);
+        return searchAgentItems(index.projects, query, limit);
+      },
+    },
+    {
+      name: 'portfolio.find_blog_posts',
+      description: 'Search portfolio blog posts.',
+      invoke: (input: unknown) => {
+        const { query, limit } = parseSearchInput(input);
+        return searchAgentItems(index.blog, query, limit);
+      },
+    },
+    {
+      name: 'portfolio.get_career_summary',
+      description: 'Return the career timeline and a short suggested summary.',
+      invoke: (): CareerSummaryOutput => ({
+        career: index.career,
+        suggestedSummary:
+          '10年以上にわたり、メーカーの社内システム開発を中心に要件定義、設計、実装、テスト、運用、インフラ構築まで幅広く担当しています。',
+      }),
+    },
+    {
+      name: 'portfolio.get_contact_routes',
+      description: 'Return contact page, GitHub, and email routes.',
+      invoke: (): AgentContact => index.contact,
+    },
+    {
+      name: 'portfolio.open_page',
+      description: 'Navigate to an internal portfolio page on the same origin.',
+      invoke: (input: unknown): OpenPageOutput => {
+        const { url } = parseOpenPageInput(input);
+        return openPortfolioPage(url);
+      },
+    },
+  ];
+}
+
+export function isSafePortfolioUrl(
+  url: string,
+  location: Location = window.location,
+  basePath = withBase('/')
+): boolean {
+  try {
+    const target = new URL(url, location.origin);
+    const normalizedBase = normalizeBasePath(basePath);
+
+    const baseRoot = normalizedBase.replace(/\/$/, '');
+
+    return (
+      (target.protocol === 'http:' || target.protocol === 'https:') &&
+      target.origin === location.origin &&
+      (target.pathname === baseRoot ||
+        target.pathname.startsWith(normalizedBase))
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function openPortfolioPage(url: string): OpenPageOutput {
+  const target = new URL(url, window.location.origin);
+
+  if (!isSafePortfolioUrl(url)) {
+    throw new Error('Navigation is limited to same-origin portfolio pages.');
+  }
+
+  window.location.href = target.href;
+
+  return {
+    navigatedTo: target.href,
+  };
+}
+
+export async function initializePortfolioTools(): Promise<void> {
+  registrationPromise ??= fetchAgentIndex()
+    .then((index) =>
+      Promise.all(createPortfolioTools(index).map((tool) => registerTool(tool)))
+    )
+    .then(() => undefined)
+    .catch((error: unknown) => {
+      console.warn('Failed to register portfolio tools.', error);
+    });
+
+  return registrationPromise;
+}
+
+async function fetchAgentIndex(): Promise<AgentIndex> {
+  const response = await fetch(withBase('/agent-index.json'), {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load agent index: ${response.status}`);
+  }
+
+  return response.json() as Promise<AgentIndex>;
+}
+
+function parseSearchContentInput(input: unknown): SearchContentInput {
+  const value = toRecord(input);
+  const type = parseSearchType(value.type);
+
+  return {
+    query: parseString(value.query),
+    type,
+    limit: parseOptionalNumber(value.limit),
+  };
+}
+
+function parseSearchInput(input: unknown): SearchInput {
+  const value = toRecord(input);
+
+  return {
+    query: parseString(value.query),
+    limit: parseOptionalNumber(value.limit),
+  };
+}
+
+function parseOpenPageInput(input: unknown): OpenPageInput {
+  const value = toRecord(input);
+
+  return {
+    url: parseString(value.url),
+  };
+}
+
+function parseSearchType(value: unknown): PortfolioSearchType {
+  if (value === 'project' || value === 'blog') {
+    return value;
+  }
+
+  return 'all';
+}
+
+function parseString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function parseOptionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function toRecord(input: unknown): Record<string, unknown> {
+  return input !== null && typeof input === 'object'
+    ? (input as Record<string, unknown>)
+    : {};
+}
+
+function normalizeBasePath(basePath: string): string {
+  const pathname = new URL(basePath, window.location.origin).pathname;
+  return pathname.endsWith('/') ? pathname : `${pathname}/`;
+}
+
+function isVitestRuntime(): boolean {
+  const runtime = globalThis as {
+    process?: { env?: { VITEST?: string } };
+  };
+
+  return runtime.process?.env?.VITEST === 'true';
+}
+
+if (typeof window !== 'undefined' && !isVitestRuntime()) {
+  void initializePortfolioTools();
+}

--- a/src/utils/agentSearch.test.ts
+++ b/src/utils/agentSearch.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { searchAgentItems } from './agentSearch';
+
+const items = [
+  {
+    title: 'Offline Todo Progressive Web App',
+    description: 'オフライン対応のタスク管理PWA',
+    tags: ['React', 'TypeScript', 'PWA'],
+  },
+  {
+    title: 'Meaningless - Aquarium Web App',
+    description: 'Three.jsとGLSLシェーダーを使用した癒し系アプリ',
+    tags: ['Three.js', 'GLSL', 'Vite'],
+  },
+  {
+    title: 'Cadenzio - Web Loop Player',
+    description: '耳コピ練習を効率化できる音楽プレイヤー',
+    tags: ['Astro', 'Web Audio API', 'PWA'],
+  },
+];
+
+describe('searchAgentItems', () => {
+  it('title一致で検索できる', () => {
+    expect(searchAgentItems(items, 'Todo')).toEqual([items[0]]);
+  });
+
+  it('description一致で検索できる', () => {
+    expect(searchAgentItems(items, 'シェーダー')).toEqual([items[1]]);
+  });
+
+  it('tags一致で検索できる', () => {
+    expect(searchAgentItems(items, 'Web Audio API')).toEqual([items[2]]);
+  });
+
+  it('大文字小文字を無視する', () => {
+    expect(searchAgentItems(items, 'three.JS')).toEqual([items[1]]);
+  });
+
+  it('空queryは空配列を返す', () => {
+    expect(searchAgentItems(items, '   ')).toEqual([]);
+  });
+
+  it('limitが効く', () => {
+    expect(searchAgentItems(items, 'app', 1)).toEqual([items[0]]);
+  });
+
+  it('limitを安全な範囲に丸める', () => {
+    expect(searchAgentItems(items, 'app', 0)).toEqual([items[0]]);
+    expect(searchAgentItems(items, 'app', 99)).toEqual([items[0], items[1]]);
+  });
+});

--- a/src/utils/agentSearch.ts
+++ b/src/utils/agentSearch.ts
@@ -1,0 +1,39 @@
+export interface SearchableAgentItem {
+  title: string;
+  description: string;
+  tags: string[];
+}
+
+const DEFAULT_LIMIT = 5;
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 20;
+
+export function searchAgentItems<TItem extends SearchableAgentItem>(
+  items: TItem[],
+  query: string,
+  limit = DEFAULT_LIMIT
+): TItem[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+
+  if (!normalizedQuery) {
+    return [];
+  }
+
+  const safeLimit = clampLimit(limit);
+
+  return items
+    .filter((item) =>
+      [item.title, item.description, ...item.tags].some((value) =>
+        value.toLocaleLowerCase().includes(normalizedQuery)
+      )
+    )
+    .slice(0, safeLimit);
+}
+
+export function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit)) {
+    return DEFAULT_LIMIT;
+  }
+
+  return Math.min(MAX_LIMIT, Math.max(MIN_LIMIT, Math.floor(limit)));
+}

--- a/src/utils/agentTypes.ts
+++ b/src/utils/agentTypes.ts
@@ -59,8 +59,16 @@ export interface AgentIndex {
   contact: AgentContact;
 }
 
+export interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  untrustedContentHint?: boolean;
+}
+
 export interface ToolDefinition<TInput = unknown, TOutput = unknown> {
   name: string;
+  title?: string;
   description?: string;
+  inputSchema?: Record<string, unknown>;
+  annotations?: ToolAnnotations;
   invoke: (input: TInput) => TOutput | Promise<TOutput>;
 }

--- a/src/utils/agentTypes.ts
+++ b/src/utils/agentTypes.ts
@@ -1,0 +1,66 @@
+export interface AgentSite {
+  name: string;
+  url: string;
+  description: string;
+}
+
+export interface AgentProfile {
+  headline: string;
+  skills: string[];
+  experience: string;
+  specialties: string[];
+}
+
+export interface AgentProject {
+  type: 'project';
+  id: string;
+  title: string;
+  description: string;
+  pubDate: string;
+  tags: string[];
+  url: string;
+  liveUrl: string | null;
+  githubUrl: string | null;
+}
+
+export interface AgentBlogPost {
+  type: 'blog';
+  id: string;
+  title: string;
+  description: string;
+  pubDate: string;
+  updatedDate: string | null;
+  tags: string[];
+  url: string;
+}
+
+export interface AgentCareerItem {
+  title: string;
+  period: string;
+  role: string;
+  description: string;
+  teamSize: string;
+  responsibilities: string;
+  techStack: string[];
+}
+
+export interface AgentContact {
+  pageUrl: string;
+  githubUrl: string;
+  email: string | null;
+}
+
+export interface AgentIndex {
+  site: AgentSite;
+  profile: AgentProfile;
+  projects: AgentProject[];
+  blog: AgentBlogPost[];
+  career: AgentCareerItem[];
+  contact: AgentContact;
+}
+
+export interface ToolDefinition<TInput = unknown, TOutput = unknown> {
+  name: string;
+  description?: string;
+  invoke: (input: TInput) => TOutput | Promise<TOutput>;
+}


### PR DESCRIPTION
## Summary
- Add a static `agent-index.json` endpoint generated from projects, blog, career, profile, and contact data.
- Add browser-side portfolio tools with WebMCP adapter registration and `window.__portfolioTools` fallback.
- Register tools with the standard `navigator.modelContext.registerTool()` API by mapping internal `invoke` callbacks to WebMCP `execute` callbacks.
- Add tested search utility for title, description, and tag matching.
- Include the updated Serena project configuration generated during the session.

## Impact
- Human-facing UI remains unchanged.
- Browser-based AI agents can discover and query portfolio content on GitHub Pages without a backend.
- Navigation tool is restricted to same-origin `/portfolio` pages.
- Non-WebMCP browsers still expose the development fallback through `window.__portfolioTools`.

## Validation
- `npm run test`
- `npm run check`
- `npm run build`