### PR TITLE
[codex] fix WebMCP compatibility descriptor

### DIFF
--- a/src/scripts/portfolio-webmcp.test.ts
+++ b/src/scripts/portfolio-webmcp.test.ts
@@ -105,6 +105,30 @@ describe('registerTool', () => {
     expect(window.__portfolioTools).toBeUndefined();
   });
 
+  it('window.webMCPがある場合もexecuteに変換して登録する', async () => {
+    const invoke = vi.fn().mockReturnValue('ok');
+    const registerTool = vi.fn();
+    window.webMCP = {
+      registerTool,
+    };
+
+    await registerToolAdapter({
+      name: 'portfolio.test',
+      description: 'Test description',
+      invoke,
+    });
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    const [tool] = registerTool.mock.calls[0];
+    expect(tool).toMatchObject({
+      name: 'portfolio.test',
+      description: 'Test description',
+    });
+    expect(tool.execute({ query: 'PWA' })).toBe('ok');
+    expect(invoke).toHaveBeenCalledWith({ query: 'PWA' });
+    expect(window.__portfolioTools).toBeUndefined();
+  });
+
   it('WebMCPがない場合はwindow.__portfolioToolsにfallback登録する', async () => {
     const invoke = vi.fn();
 

--- a/src/scripts/portfolio-webmcp.ts
+++ b/src/scripts/portfolio-webmcp.ts
@@ -37,7 +37,7 @@ interface CareerSummaryOutput {
 type PortfolioToolsRegistry = Record<string, ToolDefinition['invoke']>;
 
 interface WebMCPRegistry {
-  registerTool: (tool: ToolDefinition) => void | Promise<void>;
+  registerTool: (tool: ModelContextTool) => void | Promise<void>;
 }
 
 interface ModelContextTool {
@@ -76,7 +76,7 @@ export async function registerTool(tool: ToolDefinition): Promise<void> {
   const webMCP = window.webMCP ?? navigator.webMCP;
 
   if (webMCP?.registerTool) {
-    await webMCP.registerTool(tool);
+    await webMCP.registerTool(toModelContextTool(tool));
     return;
   }
 


### PR DESCRIPTION
## Summary
- Convert the `window.webMCP` / `navigator.webMCP` compatibility registration path to the executable ModelContext tool shape.
- Add a Vitest regression test that verifies the compatibility path registers an `execute` callback instead of the internal `invoke` callback.

## Why
The compatibility registry path was passing the internal `ToolDefinition` shape directly. That leaves registered tools without the WebMCP `execute` callback, so compatible agents or polyfills may discover a non-callable tool.

## Validation
- `npm run test -- src/scripts/portfolio-webmcp.test.ts`
- Previously verified before branching: `npm run test`, `npm run check`