### PR TITLE
[codex] Keep WebMCP data fresh

### DIFF
--- a/src/scripts/portfolio-webmcp.ts
+++ b/src/scripts/portfolio-webmcp.ts
@@ -153,8 +153,7 @@ export function createPortfolioTools(
       },
       invoke: (): CareerSummaryOutput => ({
         career: index.career,
-        suggestedSummary:
-          '10年以上にわたり、メーカーの社内システム開発を中心に要件定義、設計、実装、テスト、運用、インフラ構築まで幅広く担当しています。',
+        suggestedSummary: buildCareerSummary(index.career),
       }),
     },
     {
@@ -181,6 +180,18 @@ export function createPortfolioTools(
       },
     },
   ];
+}
+
+function buildCareerSummary(career: AgentIndex['career']): string {
+  const baseSummary =
+    '10年以上にわたり、メーカーの社内システム開発を中心に要件定義、設計、実装、テスト、運用、インフラ構築まで幅広く担当しています。';
+  const [latestCareer] = career;
+
+  if (!latestCareer) {
+    return baseSummary;
+  }
+
+  return `現在は${latestCareer.title}で${latestCareer.role}として、${latestCareer.description}を担当しています。${baseSummary}`;
 }
 
 const emptyInputSchema = {
@@ -287,6 +298,7 @@ export async function initializePortfolioTools(): Promise<void> {
 
 async function fetchAgentIndex(): Promise<AgentIndex> {
   const response = await fetch(withBase('/agent-index.json'), {
+    cache: 'no-store',
     headers: {
       Accept: 'application/json',
     },

--- a/tests/unit/scripts/portfolio-webmcp.test.ts
+++ b/tests/unit/scripts/portfolio-webmcp.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createPortfolioTools,
+  initializePortfolioTools,
   isSafePortfolioUrl,
   registerTool as registerToolAdapter,
   type AgentIndex,
@@ -55,10 +56,33 @@ const index: AgentIndex = {
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   delete window.webMCP;
   delete navigator.webMCP;
   delete navigator.modelContext;
   delete window.__portfolioTools;
+});
+
+describe('initializePortfolioTools', () => {
+  it('agent-index.jsonを常に最新取得するfetch設定で読み込む', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => index,
+    });
+    vi.stubGlobal('fetch', fetch);
+
+    await initializePortfolioTools();
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('agent-index.json'),
+      expect.objectContaining({
+        cache: 'no-store',
+        headers: {
+          Accept: 'application/json',
+        },
+      })
+    );
+  });
 });
 
 describe('registerTool', () => {
@@ -161,6 +185,35 @@ describe('createPortfolioTools', () => {
     await expect(
       Promise.resolve(getContactRoutes?.invoke({}))
     ).resolves.toEqual(index.contact);
+  });
+
+  it('portfolio.get_career_summaryで最新の経歴を反映した要約を返す', async () => {
+    const latestIndex: AgentIndex = {
+      ...index,
+      career: [
+        {
+          title: 'Azure RAG/FulltextSearch 構築支援',
+          period: '2025.07 - ',
+          role: 'SRE',
+          description: '全文検索システム導入支援',
+          teamSize: '8名',
+          responsibilities: 'PoC、要件定義、設計、実装、テスト、運用、インフラ構築',
+          techStack: ['Azure AI Search', 'Azure OpenAI', 'Java', 'React'],
+        },
+      ],
+    };
+    const tools = createPortfolioTools(latestIndex);
+    const getCareerSummary = tools.find(
+      (tool) => tool.name === 'portfolio.get_career_summary'
+    );
+
+    await expect(
+      Promise.resolve(getCareerSummary?.invoke({}))
+    ).resolves.toMatchObject({
+      career: latestIndex.career,
+      suggestedSummary:
+        '現在はAzure RAG/FulltextSearch 構築支援でSREとして、全文検索システム導入支援を担当しています。10年以上にわたり、メーカーの社内システム開発を中心に要件定義、設計、実装、テスト、運用、インフラ構築まで幅広く担当しています。',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Refresh the WebMCP career summary from the latest career entry instead of returning only static copy.
- Fetch `agent-index.json` with `cache: 'no-store'` so registered portfolio tools avoid stale index data.
- Add focused Vitest coverage for the fresh fetch behavior and latest career summary output.

## Why
WebMCP responses could look stale because one summary was hard-coded and the browser fetch could reuse an older `agent-index.json` response.

## Validation
- `npm run test`
- `npm run check`
- `npm run lint`