### PR TITLE
[codex] Polish blog markdown styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,14 +114,14 @@
       }
     },
     "node_modules/@astrojs/language-server": {
-      "version": "2.16.8",
-      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.8.tgz",
-      "integrity": "sha512-yg1pZF6hs9FaKr2fgXMOGbW7pDLgFexFjuhWilPAc8VybTU+WSnbfbhYaUL1exm6dAK4sM3aKXGcfVwss+HXbg==",
+      "version": "2.16.9",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.9.tgz",
+      "integrity": "sha512-L9kddTg+ZSO3X0Pwfx0ZPO+Z+eSSq0/39jXRyIkHzcBICzusdn2T464R4P6K0WcDZ6pMkLlFpuGS73u1pOnMSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.13.1",
-        "@astrojs/yaml2ts": "^0.2.3",
+        "@astrojs/yaml2ts": "^0.2.4",
         "@jridgewell/sourcemap-codec": "^1.5.5",
         "@volar/kit": "~2.4.28",
         "@volar/language-core": "~2.4.28",
@@ -213,13 +213,13 @@
       }
     },
     "node_modules/@astrojs/yaml2ts": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.3.tgz",
-      "integrity": "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
+      "integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "yaml": "^2.8.2"
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1032,9 +1032,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2396,17 +2396,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
-      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
+      "integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/type-utils": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/type-utils": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2419,7 +2419,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.3",
+        "@typescript-eslint/parser": "^8.59.4",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2435,16 +2435,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
-      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
+      "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2460,14 +2460,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
-      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
+      "integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.3",
-        "@typescript-eslint/types": "^8.59.3",
+        "@typescript-eslint/tsconfig-utils": "^8.59.4",
+        "@typescript-eslint/types": "^8.59.4",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2482,14 +2482,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
+      "integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3"
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2500,9 +2500,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
-      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
+      "integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2517,15 +2517,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
-      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
+      "integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2542,9 +2542,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
+      "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2556,16 +2556,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
-      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
+      "integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.3",
-        "@typescript-eslint/tsconfig-utils": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/project-service": "8.59.4",
+        "@typescript-eslint/tsconfig-utils": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2584,16 +2584,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
-      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
+      "integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3"
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2608,13 +2608,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
+      "integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/types": "8.59.4",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2883,35 +2883,20 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/ansi-regex": {
@@ -2999,9 +2984,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.3.tgz",
-      "integrity": "sha512-wvLIZQYbBZt6U8gyflBW4SLBypaqdwLZUH93rT3oT53cmQ0bTGubvMAGjqBRoheOYzYcTJZtW6czztzbu4kQ5g==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.5.tgz",
+      "integrity": "sha512-gU+4KedkbTuVgz7YoVAN+9Ftnq0GaYwejxK2NbqDzB0M9dWd0f3kXZBuaM9hzbchRFoRAJfJjFtdX9LK6Ir7ZA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
@@ -3101,19 +3086,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
-      }
-    },
-    "node_modules/astro-eslint-parser/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/astro-eslint-parser/node_modules/eslint-scope": {
@@ -3649,9 +3621,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
-      "integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -3784,9 +3756,10 @@
       "license": "MIT"
     },
     "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -3853,28 +3826,29 @@
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
@@ -4006,43 +3980,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "11.2.0",
@@ -4904,9 +4841,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4984,9 +4921,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -5061,6 +4998,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -6104,9 +6053,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
-      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -6165,6 +6114,18 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-browserify": {
@@ -7277,16 +7238,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
-      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.4.tgz",
+      "integrity": "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.3",
-        "@typescript-eslint/parser": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3"
+        "@typescript-eslint/eslint-plugin": "8.59.4",
+        "@typescript-eslint/parser": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8331,6 +8292,45 @@
       "bin": {
         "yaml-language-server": "bin/yaml-language-server"
       }
+    },
+    "node_modules/yaml-language-server/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yaml-language-server/node_modules/request-light": {
       "version": "0.5.8",

--- a/src/pages/blog/[year]/[month]/[slug].astro
+++ b/src/pages/blog/[year]/[month]/[slug].astro
@@ -280,6 +280,7 @@ const heroClass = heroImage
     padding: clamp(var(--space-lg), 4vw, var(--space-2xl));
     border-radius: var(--radius-xl);
     line-height: 1.85;
+    overflow-x: auto;
     box-shadow: var(--shadow-sm);
   }
 
@@ -357,7 +358,8 @@ const heroClass = heroImage
     background: var(--bento-muted-bg);
     color: var(--text-primary);
     font-size: 0.92em;
-    white-space: nowrap;
+    overflow-wrap: anywhere;
+    word-break: normal;
   }
 
   .content-wrapper :global(pre code) {
@@ -376,10 +378,8 @@ const heroClass = heroImage
   }
 
   .content-wrapper :global(table) {
-    display: block;
-    width: 100%;
-    max-width: 100%;
-    overflow-x: auto;
+    width: max-content;
+    min-width: 100%;
     border: 1px solid var(--glass-border);
     border-radius: var(--radius-md);
     border-spacing: 0;

--- a/src/pages/blog/[year]/[month]/[slug].astro
+++ b/src/pages/blog/[year]/[month]/[slug].astro
@@ -277,9 +277,10 @@ const heroClass = heroImage
   }
 
   .content-wrapper {
-    padding: var(--space-2xl);
+    padding: clamp(var(--space-lg), 4vw, var(--space-2xl));
     border-radius: var(--radius-xl);
-    line-height: 1.8;
+    line-height: 1.85;
+    box-shadow: var(--shadow-sm);
   }
 
   .content-wrapper :global(h1),
@@ -298,9 +299,25 @@ const heroClass = heroImage
     margin-top: 0;
   }
 
+  .content-wrapper :global(h2) {
+    font-size: clamp(var(--font-size-2xl), 3vw, var(--font-size-3xl));
+    padding-top: var(--space-lg);
+    border-top: 1px solid var(--glass-border);
+  }
+
+  .content-wrapper :global(h2):first-child {
+    padding-top: 0;
+    border-top: 0;
+  }
+
+  .content-wrapper :global(h3) {
+    font-size: var(--font-size-2xl);
+  }
+
   .content-wrapper :global(p) {
     color: var(--text-secondary);
     margin: 0 0 var(--space-md) 0;
+    line-height: 1.85;
   }
 
   .content-wrapper :global(ul),
@@ -321,11 +338,33 @@ const heroClass = heroImage
     padding: var(--space-md);
     overflow-x: auto;
     margin: var(--space-lg) 0;
+    white-space: pre;
+    word-break: normal;
   }
 
   .content-wrapper :global(code) {
     font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
     font-size: 0.95em;
+  }
+
+  .content-wrapper :global(p code),
+  .content-wrapper :global(li code),
+  .content-wrapper :global(td code),
+  .content-wrapper :global(th code) {
+    padding: 0.12em 0.42em;
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-sm);
+    background: var(--bento-muted-bg);
+    color: var(--text-primary);
+    font-size: 0.92em;
+    white-space: nowrap;
+  }
+
+  .content-wrapper :global(pre code) {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    white-space: inherit;
   }
 
   .content-wrapper :global(blockquote) {
@@ -336,82 +375,115 @@ const heroClass = heroImage
     color: var(--text-secondary);
   }
 
+  .content-wrapper :global(table) {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    overflow-x: auto;
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-md);
+    border-spacing: 0;
+    border-collapse: separate;
+    background: var(--bento-card-bg);
+    color: var(--text-secondary);
+    box-shadow: var(--shadow-sm);
+    margin: var(--space-lg) 0;
+  }
+
+  .content-wrapper :global(thead) {
+    background: var(--bento-muted-bg);
+  }
+
+  .content-wrapper :global(th),
+  .content-wrapper :global(td) {
+    padding: var(--space-sm) var(--space-md);
+    border-bottom: 1px solid var(--glass-border);
+    text-align: left;
+    vertical-align: top;
+    line-height: 1.65;
+    min-width: 9rem;
+  }
+
+  .content-wrapper :global(th) {
+    color: var(--text-primary);
+    font-weight: 700;
+    font-size: var(--font-size-sm);
+  }
+
+  .content-wrapper :global(td) {
+    font-size: var(--font-size-sm);
+  }
+
+  .content-wrapper :global(th:not(:last-child)),
+  .content-wrapper :global(td:not(:last-child)) {
+    border-right: 1px solid var(--glass-border);
+  }
+
+  .content-wrapper :global(tbody tr:last-child td) {
+    border-bottom: 0;
+  }
+
+  .content-wrapper :global(tbody tr:hover) {
+    background: var(--bento-muted-bg);
+  }
+
   .content-wrapper :global(.admonition) {
     --admonition-color: #0969da;
-    --admonition-icon-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='currentColor' d='M8 1.75a6.25 6.25 0 1 1 0 12.5A6.25 6.25 0 0 1 8 1.75m0-1.5a7.75 7.75 0 1 0 0 15.5A7.75 7.75 0 0 0 8 .25Zm-.75 4a.75.75 0 1 1 1.5 0 .75.75 0 0 1-1.5 0ZM8 6.75c-.414 0-.75.336-.75.75v4a.75.75 0 0 0 1.5 0v-4c0-.414-.336-.75-.75-.75Z'/></svg>");
     display: grid;
-    grid-template-columns: 22px 1fr;
-    grid-template-rows: auto auto;
-    column-gap: 10px;
-    row-gap: 6px;
-    padding: 14px 16px;
-    border-radius: 8px;
+    grid-template-columns: 1fr;
+    row-gap: var(--space-xs);
+    padding: var(--space-md);
+    border-radius: var(--radius-md);
     border: 1px solid var(--glass-border);
-    border-left: 6px solid var(--admonition-color);
+    border-left: 3px solid var(--admonition-color);
     background: color-mix(
       in srgb,
-      var(--bento-muted-bg) 88%,
-      var(--admonition-color) 12%
+      var(--bento-card-bg) 92%,
+      var(--admonition-color) 8%
     );
     margin: var(--space-lg) 0;
     color: var(--text-secondary);
-    box-shadow:
-      inset 0 1px 2px rgba(255, 255, 255, 0.12),
-      inset 0 -1px 4px rgba(0, 0, 0, 0.16);
-  }
-
-  .content-wrapper :global(.admonition)::before {
-    content: '';
-    width: 20px;
-    height: 20px;
-    background: var(--admonition-color);
-    mask: var(--admonition-icon-url) center / contain no-repeat;
-    -webkit-mask: var(--admonition-icon-url) center / contain no-repeat;
-    align-self: start;
-    grid-column: 1;
-    grid-row: 1;
+    box-shadow: var(--shadow-sm);
   }
 
   .content-wrapper :global(.admonition)::after {
     content: attr(data-label);
     color: var(--admonition-color);
     font-weight: 700;
-    font-size: 1em;
+    font-size: var(--font-size-xs);
+    letter-spacing: 0.08em;
     line-height: 1.2;
-    align-self: center;
-    grid-column: 2;
+    text-transform: uppercase;
+    grid-column: 1;
     grid-row: 1;
   }
 
-  .content-wrapper :global(.admonition p) {
-    grid-column: 1 / -1;
+  .content-wrapper :global(.admonition p),
+  .content-wrapper :global(.admonition ul),
+  .content-wrapper :global(.admonition ol) {
+    grid-column: 1;
     margin: 0;
     color: var(--text-secondary);
   }
 
   .content-wrapper :global(.admonition-note) {
     --admonition-color: #58a6ff;
-    --admonition-icon-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='currentColor' d='M8 1.75a6.25 6.25 0 1 1 0 12.5A6.25 6.25 0 0 1 8 1.75m0-1.5a7.75 7.75 0 1 0 0 15.5A7.75 7.75 0 0 0 8 .25Zm-.75 4a.75.75 0 1 1 1.5 0 .75.75 0 0 1-1.5 0ZM8 6.75c-.414 0-.75.336-.75.75v4a.75.75 0 0 0 1.5 0v-4c0-.414-.336-.75-.75-.75Z'/></svg>");
   }
 
   .content-wrapper :global(.admonition-tip) {
     --admonition-color: #3fb950;
-    --admonition-icon-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='currentColor' d='M5.5 2.75a2.5 2.5 0 0 1 5 0c0 .824-.418 1.54-1.054 2-.167.121-.32.265-.452.428a.75.75 0 0 0-.174.48v.592a.75.75 0 0 1-.75.75h-.5a.75.75 0 0 1-.75-.75v-.592a.75.75 0 0 0-.174-.48 2.76 2.76 0 0 0-.452-.428 2.486 2.486 0 0 1-1.094-2Zm2.25 8.448a.25.25 0 0 1 .25-.198h.5a.25.25 0 0 1 .25.198l.083.416a1.25 1.25 0 0 1-1.166 1.536h-.334a1.25 1.25 0 0 1-1.166-1.536l.083-.416Zm.25-11.198a4 4 0 0 0-2.3 7.28v.582a2.25 2.25 0 0 0 2.25 2.25h.5a2.25 2.25 0 0 0 2.25-2.25v-.582a4 4 0 0 0-2.7-7.28Z'/></svg>");
   }
 
   .content-wrapper :global(.admonition-important) {
     --admonition-color: #a371f7;
-    --admonition-icon-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='currentColor' d='M4.75 2A.75.75 0 0 0 4 2.75V5c0 .69.56 1.25 1.25 1.25h.548l.768 6.148a.75.75 0 0 0 1.488 0L8.822 6.25h.928c.69 0 1.25-.56 1.25-1.25V2.75A.75.75 0 0 0 10.25 2ZM6 3.5h4V5H6Zm1.314 8.75-.6-5h.572l.314 2.516a.75.75 0 0 0 1.488 0L9.4 7.25h.55l-.613 5.034a.25.25 0 0 1-.248.216H7.56a.25.25 0 0 1-.246-.25Z'/></svg>");
   }
 
   .content-wrapper :global(.admonition-warning) {
     --admonition-color: #d29922;
-    --admonition-icon-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='currentColor' d='M7.022 1.566c.38-.654 1.322-.654 1.703 0l6.016 10.354c.37.636-.088 1.43-.851 1.43H1.857c-.763 0-1.22-.794-.85-1.43ZM8 5.75a.75.75 0 0 0-.75.75v2.5a.75.75 0 1 0 1.5 0V6.5A.75.75 0 0 0 8 5.75Zm0 5.5a.875.875 0 1 0 0 1.75.875.875 0 0 0 0-1.75Z'/></svg>");
   }
 
   .content-wrapper :global(.admonition-caution) {
     --admonition-color: #f85149;
-    --admonition-icon-url: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='currentColor' d='M6.343 1.75h3.314a1.75 1.75 0 0 1 1.237.513l2.843 2.843c.329.329.513.776.513 1.237v3.314a1.75 1.75 0 0 1-.513 1.237l-2.843 2.843a1.75 1.75 0 0 1-1.237.513H6.343a1.75 1.75 0 0 1-1.237-.513L2.263 10.9a1.75 1.75 0 0 1-.513-1.237V6.343c0-.461.184-.908.513-1.237l2.843-2.843A1.75 1.75 0 0 1 6.343 1.75Zm3.314-1.5H6.343a3.25 3.25 0 0 0-2.318.96L1.182 5.053A3.25 3.25 0 0 0 .223 7.37v3.314a3.25 3.25 0 0 0 .96 2.318l2.843 2.843a3.25 3.25 0 0 0 2.317.96h3.314a3.25 3.25 0 0 0 2.318-.96l2.843-2.843a3.25 3.25 0 0 0 .96-2.318V7.37a3.25 3.25 0 0 0-.96-2.318L11.975 1.21a3.25 3.25 0 0 0-2.318-.96ZM5.5 6.75a.75.75 0 0 0-1.5 0v2.5a.75.75 0 0 0 1.5 0Zm6.5 0a.75.75 0 0 0-1.5 0v2.5a.75.75 0 0 0 1.5 0Z'/></svg>");
   }
 
   .article-footer {
@@ -443,6 +515,13 @@ const heroClass = heroImage
 
     .content-wrapper {
       padding: var(--space-lg);
+      border-radius: var(--radius-lg);
+    }
+
+    .content-wrapper :global(th),
+    .content-wrapper :global(td) {
+      padding: var(--space-xs) var(--space-sm);
+      min-width: 8rem;
     }
 
     .author-impression__avatar {

--- a/tests/unit/pages/blog.test.ts
+++ b/tests/unit/pages/blog.test.ts
@@ -193,10 +193,22 @@ describe('ブログ機能', () => {
     );
 
     expect(detailPage).toMatch(/\.content-wrapper\s+:global\(table\)\s*\{/);
-    expect(detailPage).toMatch(/overflow-x:\s*auto/);
     expect(detailPage).toMatch(/\.content-wrapper\s+:global\(th\)/);
     expect(detailPage).toMatch(/\.content-wrapper\s+:global\(td\)/);
     expect(detailPage).toMatch(/border-spacing:\s*0/);
+  });
+
+  it('ブログ詳細ページのMarkdownテーブルはtable要素の表示種別を維持する', () => {
+    const detailPage = load(
+      '../../../src/pages/blog/[year]/[month]/[slug].astro'
+    );
+
+    expect(detailPage).not.toMatch(
+      /\.content-wrapper\s+:global\(table\)\s*\{[^}]*display:\s*block/s
+    );
+    expect(detailPage).toMatch(
+      /\.content-wrapper\s*\{[^}]*overflow-x:\s*auto/s
+    );
   });
 
   it('ブログ詳細ページは本文コンテナとタイトルの幅を追加で制限しない', () => {
@@ -218,6 +230,17 @@ describe('ブログ機能', () => {
     expect(detailPage).toMatch(/\.content-wrapper\s+:global\(p code\)/);
     expect(detailPage).toMatch(/\.content-wrapper\s+:global\(pre code\)/);
     expect(detailPage).toMatch(/white-space:\s*pre/);
+  });
+
+  it('ブログ詳細ページのインラインコードは狭い画面で折り返せる', () => {
+    const detailPage = load(
+      '../../../src/pages/blog/[year]/[month]/[slug].astro'
+    );
+
+    expect(detailPage).not.toMatch(
+      /\.content-wrapper\s+:global\(p code\),[\s\S]*?white-space:\s*nowrap/
+    );
+    expect(detailPage).toMatch(/overflow-wrap:\s*anywhere/);
   });
 
   it('ブログ詳細ページのadmonitionは控えめな単一カラムで表示する', () => {

--- a/tests/unit/pages/blog.test.ts
+++ b/tests/unit/pages/blog.test.ts
@@ -187,6 +187,54 @@ describe('ブログ機能', () => {
     expect(detailPage).toContain('content-wrapper card-glass');
   });
 
+  it('ブログ詳細ページはMarkdownテーブルにBentoスタイルを当てる', () => {
+    const detailPage = load(
+      '../../../src/pages/blog/[year]/[month]/[slug].astro'
+    );
+
+    expect(detailPage).toMatch(/\.content-wrapper\s+:global\(table\)\s*\{/);
+    expect(detailPage).toMatch(/overflow-x:\s*auto/);
+    expect(detailPage).toMatch(/\.content-wrapper\s+:global\(th\)/);
+    expect(detailPage).toMatch(/\.content-wrapper\s+:global\(td\)/);
+    expect(detailPage).toMatch(/border-spacing:\s*0/);
+  });
+
+  it('ブログ詳細ページは本文コンテナとタイトルの幅を追加で制限しない', () => {
+    const detailPage = load(
+      '../../../src/pages/blog/[year]/[month]/[slug].astro'
+    );
+
+    expect(detailPage).not.toMatch(
+      /\.article-body\s+\.container,\s*\.article-footer\s+\.container\s*\{[^}]*max-width:\s*920px/s
+    );
+    expect(detailPage).not.toMatch(/max-width:\s*12em/);
+  });
+
+  it('ブログ詳細ページはインラインコードとpre内コードを別々に整形する', () => {
+    const detailPage = load(
+      '../../../src/pages/blog/[year]/[month]/[slug].astro'
+    );
+
+    expect(detailPage).toMatch(/\.content-wrapper\s+:global\(p code\)/);
+    expect(detailPage).toMatch(/\.content-wrapper\s+:global\(pre code\)/);
+    expect(detailPage).toMatch(/white-space:\s*pre/);
+  });
+
+  it('ブログ詳細ページのadmonitionは控えめな単一カラムで表示する', () => {
+    const detailPage = load(
+      '../../../src/pages/blog/[year]/[month]/[slug].astro'
+    );
+
+    expect(detailPage).toMatch(
+      /\.content-wrapper\s+:global\(\.admonition\)\s*\{[^}]*grid-template-columns:\s*1fr/s
+    );
+    expect(detailPage).not.toContain('--admonition-icon-url');
+    expect(detailPage).not.toMatch(/mask:\s*var\(--admonition-icon-url\)/);
+    expect(detailPage).toMatch(
+      /\.content-wrapper\s+:global\(\.admonition p\),\s*\.content-wrapper\s+:global\(\.admonition ul\),\s*\.content-wrapper\s+:global\(\.admonition ol\)\s*\{[^}]*grid-column:\s*1/s
+    );
+  });
+
   it('ブログ詳細のタグpillが小さめのフォントサイズで表示される', () => {
     const detailPage = load(
       '../../../src/pages/blog/[year]/[month]/[slug].astro'


### PR DESCRIPTION
## Summary

- Style Markdown tables in blog detail pages with Bento-compatible borders, spacing, hover state, and horizontal overflow handling.
- Improve inline code and code block rendering while keeping the blog detail container at the existing site width.
- Simplify admonition blocks into a quieter single-column treatment so NOTE-style content does not overpower the article body.
- Include the updated `package-lock.json` from dependency synchronization.

## Validation

- `npm run test -- --run tests/unit/pages/blog.test.ts`
- `npm run lint`
- `npm run check`