### PR TITLE
[codex] add agent discovery metadata

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,12 @@
+# Portfolio LLM Guide
+
+This site exposes portfolio information for AI agents through WebMCP when the browser supports it.
+
+## WebMCP tools
+
+- `portfolio.search_content`: Search across projects and blog posts.
+- `portfolio.find_projects`: Search portfolio projects.
+- `portfolio.find_blog_posts`: Search blog posts.
+- `portfolio.get_career_summary`: Return the career timeline and a short summary.
+- `portfolio.get_contact_routes`: Return contact page, GitHub, and email routes.
+- `portfolio.open_page`: Navigate to an internal portfolio page on the same origin.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -45,6 +45,16 @@ const navItems = baseNavItems.map((item) => {
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href={faviconHref} />
+    <link
+      rel="alternate"
+      type="text/markdown"
+      title="LLM guide"
+      href={withBase('/llms.txt')}
+    />
+    <meta
+      name="ai-agent-capabilities"
+      content="WebMCP; portfolio search; projects; blog; career summary; contact routes"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/tests/unit/layouts/Layout.agentDiscovery.test.ts
+++ b/tests/unit/layouts/Layout.agentDiscovery.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const layoutPath = resolve(currentDir, '../../../src/layouts/Layout.astro');
+
+function loadLayoutSource(): string {
+  return readFileSync(layoutPath, 'utf-8');
+}
+
+describe('Layout agent discovery metadata', () => {
+  it('advertises the LLM guide as a base-aware markdown alternate link', () => {
+    const layout = loadLayoutSource();
+
+    expect(layout).toMatch(/rel=['"]alternate['"]/);
+    expect(layout).toMatch(/type=['"]text\/markdown['"]/);
+    expect(layout).toMatch(/title=['"]LLM guide['"]/);
+    expect(layout).toMatch(/href=\{withBase\(['"]\/llms\.txt['"]\)\}/);
+  });
+
+  it('describes the WebMCP portfolio tools for AI agents', () => {
+    const layout = loadLayoutSource();
+
+    expect(layout).toMatch(/name=['"]ai-agent-capabilities['"]/);
+    expect(layout).toMatch(
+      /content=['"]WebMCP; portfolio search; projects; blog; career summary; contact routes['"]/
+    );
+  });
+});

--- a/tests/unit/public/llms.test.ts
+++ b/tests/unit/public/llms.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const llmsPath = resolve(currentDir, '../../../public/llms.txt');
+
+function loadLlmsGuide(): string {
+  return readFileSync(llmsPath, 'utf-8');
+}
+
+describe('llms.txt', () => {
+  it('documents the portfolio WebMCP tools for agents', () => {
+    const guide = loadLlmsGuide();
+
+    expect(guide).toContain('WebMCP');
+    expect(guide).toContain('portfolio.search_content');
+    expect(guide).toContain('portfolio.find_projects');
+    expect(guide).toContain('portfolio.find_blog_posts');
+    expect(guide).toContain('portfolio.get_career_summary');
+    expect(guide).toContain('portfolio.get_contact_routes');
+  });
+});


### PR DESCRIPTION
## Summary

- Add an alternate markdown link to `/llms.txt` from the shared layout head.
- Add `ai-agent-capabilities` metadata describing the WebMCP portfolio capabilities.
- Add `public/llms.txt` documenting the portfolio WebMCP tools for agents.
- Cover the discovery metadata and guide with unit tests.

## Impact

AI agents can discover that the portfolio exposes WebMCP-backed search, project, blog, career summary, and contact route capabilities. The `llms.txt` guide is served as a static asset and linked with the configured base path.

## Validation

- `npm run test -- tests/unit/layouts/Layout.agentDiscovery.test.ts`
- `npm run test -- tests/unit/public/llms.test.ts`
- `npm run test -- tests/unit/layouts tests/unit/public`
- `npm run check`
- `npm run lint`
- `npm run build`