### PR TITLE
[codex] add WebMCP footer guide link

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,6 +2,25 @@
 
 This site exposes portfolio information for AI agents through WebMCP when the browser supports it.
 
+## Status
+
+WebMCP is enabled for this portfolio. The page registers portfolio tools in a supported browser or agent, and falls back to the normal web UI when WebMCP is unavailable.
+
+## How to use
+
+Open the portfolio in a supported browser or agent, discover the `portfolio.*` WebMCP tools, and call the tool that matches the task. For example:
+
+```json
+{
+  "tool": "portfolio.search_content",
+  "input": {
+    "query": "WebMCP",
+    "type": "all",
+    "limit": 5
+  }
+}
+```
+
 ## WebMCP tools
 
 - `portfolio.search_content`: Search across projects and blog posts.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -99,6 +99,9 @@ const navItems = baseNavItems.map((item) => {
         <div class="footer-content">
           <span>&copy; {new Date().getFullYear()} penpenguin.</span>
           <div class="social-links">
+            <Link href="/llms.txt" title="WebMCP tools and usage">
+              WebMCP enabled
+            </Link>
             <a
               href={import.meta.env.PUBLIC_GITHUB_URL || 'https://github.com'}
               target="_blank"

--- a/tests/unit/layouts/Layout.footerCopy.test.ts
+++ b/tests/unit/layouts/Layout.footerCopy.test.ts
@@ -22,6 +22,14 @@ describe('Layout footer copy', () => {
     expect(loadLayoutSource()).not.toContain('Built with Astro');
   });
 
+  it('links to the LLM guide from a WebMCP enabled footer affordance', () => {
+    const layout = loadLayoutSource();
+
+    expect(layout).toContain('WebMCP enabled');
+    expect(layout).toMatch(/href=\{withBase\(['"]\/llms\.txt['"]\)\}/);
+    expect(layout).toContain('WebMCP tools and usage');
+  });
+
   it('balances footer text spacing against the bottom viewport edge', () => {
     const layout = loadLayoutSource();
     expect(layout).toMatch(

--- a/tests/unit/public/llms.test.ts
+++ b/tests/unit/public/llms.test.ts
@@ -21,5 +21,15 @@ describe('llms.txt', () => {
     expect(guide).toContain('portfolio.find_blog_posts');
     expect(guide).toContain('portfolio.get_career_summary');
     expect(guide).toContain('portfolio.get_contact_routes');
+    expect(guide).toContain('portfolio.open_page');
+  });
+
+  it('explains how supported agents can use the WebMCP tools', () => {
+    const guide = loadLlmsGuide();
+
+    expect(guide).toContain('Status');
+    expect(guide).toContain('How to use');
+    expect(guide).toContain('supported browser or agent');
+    expect(guide).toContain('"query": "WebMCP"');
   });
 });


### PR DESCRIPTION
## Summary

- Add a `WebMCP enabled` footer link to the existing `llms.txt` guide.
- Expand `llms.txt` with WebMCP status, usage guidance, and a sample `portfolio.search_content` invocation.
- Add focused tests for the footer affordance and LLM guide content.

## Impact

Visitors and supported AI agents can now discover that WebMCP is enabled and find the available portfolio tools from the footer.

## Validation

- `npm test -- tests/unit/layouts/Layout.footerCopy.test.ts tests/unit/public/llms.test.ts --run`
- `npm run check`
- `npm run lint`