### PR TITLE
[codex] Fix Pagefind search after transitions

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -101,11 +101,17 @@ const navItems = baseNavItems.map((item) => {
     </nav>
 
     <pagefind-config
+      transition:persist
+      transition:animate="none"
       bundle-path={pagefindBundlePath}
       base-url={pagefindBaseUrl}
       excerpt-length="24"
     ></pagefind-config>
-    <pagefind-modal reset-on-close></pagefind-modal>
+    <pagefind-modal
+      reset-on-close
+      transition:persist
+      transition:animate="none"
+    ></pagefind-modal>
 
     <main>
       <slot />
@@ -216,6 +222,7 @@ const navItems = baseNavItems.map((item) => {
 
   .nav-links {
     display: flex;
+    align-items: stretch;
     gap: var(--space-2xs);
   }
 
@@ -253,15 +260,66 @@ const navItems = baseNavItems.map((item) => {
     --pagefind-ui-border: var(--glass-border);
     --pagefind-ui-border-radius: var(--radius-md);
     --pagefind-ui-font: inherit;
+    --pf-background: transparent;
+    --pf-border: transparent;
+    --pf-border-focus: transparent;
+    --pf-border-radius: var(--radius-md);
+    --pf-font: var(--font-family-base);
+    --pf-input-height: auto;
+    --pf-outline-focus: var(--text-accent);
+    --pf-text: var(--text-primary);
+    --pf-text-muted: var(--text-secondary);
+    --pf-text-secondary: var(--text-secondary);
 
     display: inline-flex;
-    min-height: 100%;
+    align-items: stretch;
     color: var(--text-secondary);
     font: inherit;
+    line-height: 1.6;
   }
 
   .search-trigger:hover {
+    --pf-text-muted: var(--text-primary);
+
     color: var(--text-primary);
+  }
+
+  :global(:is(*, #\#):is(*, #\#):is(*, #\#) .search-trigger .pf-trigger-btn) {
+    display: inline-flex;
+    align-items: center;
+    width: auto;
+    height: auto;
+    padding: var(--space-xs) var(--space-sm);
+    background: transparent;
+    border: 0;
+    border-radius: var(--radius-md);
+    box-shadow: none;
+    color: var(--text-secondary);
+    font: inherit;
+    font-weight: 500;
+    line-height: 1.6;
+    transition:
+      background 0.2s ease,
+      color 0.2s ease;
+  }
+
+  :global(:is(*, #\#):is(*, #\#):is(*, #\#) .search-trigger .pf-trigger-btn:hover) {
+    background: transparent;
+    color: var(--text-primary);
+  }
+
+  :global(:is(*, #\#):is(*, #\#):is(*, #\#) .search-trigger .pf-trigger-btn:focus-visible) {
+    outline: 2px solid var(--text-accent);
+    outline-offset: 3px;
+  }
+
+  :global(:is(*, #\#):is(*, #\#):is(*, #\#) .search-trigger .pf-trigger-icon) {
+    background: currentColor;
+  }
+
+  :global(:is(*, #\#):is(*, #\#):is(*, #\#) .search-trigger .pf-trigger-text) {
+    flex: 0 0 auto;
+    color: currentColor;
   }
 
   main {
@@ -323,6 +381,11 @@ const navItems = baseNavItems.map((item) => {
     }
 
     .search-trigger {
+      font-size: var(--font-size-sm);
+    }
+
+    :global(:is(*, #\#):is(*, #\#):is(*, #\#) .search-trigger .pf-trigger-btn) {
+      padding: var(--space-2xs) var(--space-xs);
       font-size: var(--font-size-sm);
     }
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -69,6 +69,14 @@ const navItems = baseNavItems.map((item) => {
     <ClientRouter />
   </head>
   <body>
+    <pagefind-config
+      transition:persist
+      transition:animate="none"
+      bundle-path={pagefindBundlePath}
+      base-url={pagefindBaseUrl}
+      excerpt-length="24"
+    ></pagefind-config>
+
     <nav class="navbar" transition:persist transition:animate="none">
       <div class="container">
         <div class="navbar-content">
@@ -100,13 +108,6 @@ const navItems = baseNavItems.map((item) => {
       </div>
     </nav>
 
-    <pagefind-config
-      transition:persist
-      transition:animate="none"
-      bundle-path={pagefindBundlePath}
-      base-url={pagefindBaseUrl}
-      excerpt-length="24"
-    ></pagefind-config>
     <pagefind-modal
       reset-on-close
       transition:persist

--- a/tests/unit/search/pagefind.test.ts
+++ b/tests/unit/search/pagefind.test.ts
@@ -56,6 +56,20 @@ describe('Pagefind search integration', () => {
     );
   });
 
+  it('places Pagefind config before UI components so options are registered first', () => {
+    const layout = readSource('src/layouts/Layout.astro');
+
+    const configIndex = layout.indexOf('<pagefind-config');
+    const triggerIndex = layout.indexOf('<pagefind-modal-trigger');
+    const modalIndex = layout.indexOf('<pagefind-modal');
+
+    expect(configIndex).toBeGreaterThan(-1);
+    expect(triggerIndex).toBeGreaterThan(-1);
+    expect(modalIndex).toBeGreaterThan(-1);
+    expect(configIndex).toBeLessThan(triggerIndex);
+    expect(configIndex).toBeLessThan(modalIndex);
+  });
+
   it('aligns the search trigger with the other header navigation items', () => {
     const layout = readSource('src/layouts/Layout.astro');
 

--- a/tests/unit/search/pagefind.test.ts
+++ b/tests/unit/search/pagefind.test.ts
@@ -33,7 +33,7 @@ describe('Pagefind search integration', () => {
     expect(layout).toContain('<pagefind-config');
     expect(layout).toContain('bundle-path={pagefindBundlePath}');
     expect(layout).toContain('base-url={pagefindBaseUrl}');
-    expect(layout).toContain('<pagefind-modal reset-on-close>');
+    expect(layout).toMatch(/<pagefind-modal\s+reset-on-close/);
     expect(layout).toContain('<pagefind-modal-trigger');
     expect(layout).toContain('shortcut="mod+k"');
     expect(layout).toContain('hide-shortcut');
@@ -42,6 +42,34 @@ describe('Pagefind search integration', () => {
     );
     expect(layout).not.toMatch(
       /<pagefind-modal-trigger[^>]*class="[^"]*\bnav-link\b/
+    );
+  });
+
+  it('keeps Pagefind modal utilities alive across Astro view transitions', () => {
+    const layout = readSource('src/layouts/Layout.astro');
+
+    expect(layout).toMatch(
+      /<pagefind-config\b[^>]*transition:persist[^>]*transition:animate="none"[^>]*>/s
+    );
+    expect(layout).toMatch(
+      /<pagefind-modal\b[^>]*transition:persist[^>]*transition:animate="none"[^>]*>/s
+    );
+  });
+
+  it('aligns the search trigger with the other header navigation items', () => {
+    const layout = readSource('src/layouts/Layout.astro');
+
+    expect(layout).toMatch(
+      /\.nav-links\s*\{[^}]*align-items:\s*stretch/s
+    );
+    expect(layout).toContain(
+      ':global(:is(*, #\\#):is(*, #\\#):is(*, #\\#) .search-trigger .pf-trigger-btn)'
+    );
+    expect(layout).toMatch(
+      /:global\([\s\S]*?\.search-trigger \.pf-trigger-btn\)\s*\{[^}]*padding:\s*var\(--space-xs\) var\(--space-sm\)/s
+    );
+    expect(layout).toMatch(
+      /@media\s*\(max-width:\s*768px\)[\s\S]*:global\([\s\S]*?\.search-trigger \.pf-trigger-btn\)\s*\{[^}]*padding:\s*var\(--space-2xs\) var\(--space-xs\)/s
     );
   });
 


### PR DESCRIPTION
## Summary
- Persist Pagefind config and modal utilities across Astro view transitions so the search trigger keeps opening a connected modal after client-side navigation.
- Align the generated Pagefind search trigger with the surrounding header nav items on desktop and mobile.
- Add regression coverage for the persisted Pagefind utilities and header trigger alignment.

## Root Cause
The navbar persisted across Astro view transitions, but the Pagefind config and modal did not. After navigation, the persisted trigger could point at stale Pagefind modal utility state, which made search stop opening reliably.

## Validation
- `npm run test -- tests/unit/search/pagefind.test.ts tests/unit/layouts/Layout.navActive.test.ts tests/unit/layouts/layout-responsive.test.ts tests/unit/layouts/Layout.favicon.test.ts`
- `npm run check`
- `npm run build`
- `npm run lint`
- `npx playwright install chromium`
- Playwright desktop/mobile smoke checks against `astro preview`: search opens before and after navigation, console errors are empty, and nav/search trigger height deltas are `0px`
- `npm run test:visual`