### PR TITLE
[codex] Fix Pagefind modal after Astro navigation

### DIFF
--- a/.serena/memories/pagefind_astro_transition_registry.md
+++ b/.serena/memories/pagefind_astro_transition_registry.md
@@ -1,0 +1,5 @@
+# Pagefind + Astro View Transitions
+
+Pagefind Component UI keeps disconnected custom elements in its internal `components` / `componentsByType` registry after Astro ClientRouter page swaps. If stale utilities remain, modal triggers can resolve an old modal and the search dialog may fail to appear after navigation.
+
+This project handles it in `src/scripts/pagefind-view-transitions.ts` by pruning disconnected Pagefind components on `astro:page-load`, `astro:after-swap`, and immediately before search trigger click / mod+k activation. Layout imports that module next to `portfolio-webmcp`.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -139,6 +139,7 @@ const navItems = baseNavItems.map((item) => {
     </footer>
     <script>
       import '../scripts/portfolio-webmcp';
+      import '../scripts/pagefind-view-transitions';
     </script>
     <script is:inline>
       const normalizePathname = (input) => {

--- a/src/scripts/pagefind-view-transitions.ts
+++ b/src/scripts/pagefind-view-transitions.ts
@@ -1,0 +1,149 @@
+type PagefindComponent = {
+  componentSubtype?: string | null;
+  isConnected?: boolean;
+};
+
+type PagefindInstance = {
+  components?: PagefindComponent[];
+  componentsByType?: Record<string, PagefindComponent[]>;
+  reconcileAria?: () => void;
+};
+
+type PagefindComponentsApi = {
+  getInstanceManager?: () =>
+    | {
+        getInstance?: (name?: string) => PagefindInstance | undefined;
+      }
+    | undefined;
+};
+
+type PagefindWindow = Window & {
+  PagefindComponents?: PagefindComponentsApi;
+};
+
+const isConnectedPagefindComponent = (component: PagefindComponent) =>
+  component.isConnected !== false;
+
+const getDefaultPagefindInstance = (
+  pagefindComponents?: PagefindComponentsApi
+) => pagefindComponents?.getInstanceManager?.()?.getInstance?.('default');
+
+export const pruneDisconnectedPagefindComponents = (
+  pagefindComponents?: PagefindComponentsApi
+) => {
+  const instance = getDefaultPagefindInstance(pagefindComponents);
+
+  if (!instance) {
+    return;
+  }
+
+  // Pagefind keeps disconnected custom elements in this registry after Astro swaps.
+  if (Array.isArray(instance.components)) {
+    instance.components = instance.components.filter(
+      isConnectedPagefindComponent
+    );
+  }
+
+  if (instance.componentsByType) {
+    Object.entries(instance.componentsByType).forEach(([type, components]) => {
+      if (Array.isArray(components)) {
+        instance.componentsByType![type] = components.filter(
+          isConnectedPagefindComponent
+        );
+      }
+    });
+  }
+
+  instance.reconcileAria?.();
+};
+
+const closestPagefindTrigger = (target: EventTarget | null) => {
+  const targetWithClosest = target as {
+    closest?: (selector: string) => Element | null;
+  } | null;
+
+  return targetWithClosest?.closest?.('pagefind-modal-trigger') ?? null;
+};
+
+const isEditableTarget = (target: EventTarget | null) => {
+  const element = target as
+    | {
+        isContentEditable?: boolean;
+        tagName?: string;
+      }
+    | null
+    | undefined;
+  const tagName = element?.tagName?.toUpperCase();
+
+  return (
+    element?.isContentEditable || tagName === 'INPUT' || tagName === 'TEXTAREA'
+  );
+};
+
+const usesMetaAsModifier = (windowRef: PagefindWindow) => {
+  const platform =
+    windowRef.navigator?.platform || windowRef.navigator?.userAgent;
+
+  return /mac|iphone|ipad|ipod/i.test(platform ?? '');
+};
+
+const isSearchShortcut = (event: KeyboardEvent, windowRef: PagefindWindow) => {
+  if (
+    event.key.toLowerCase() !== 'k' ||
+    event.altKey ||
+    event.shiftKey ||
+    isEditableTarget(event.target)
+  ) {
+    return false;
+  }
+
+  return usesMetaAsModifier(windowRef)
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey;
+};
+
+const schedulePrune = (windowRef: PagefindWindow) => {
+  const prune = () =>
+    pruneDisconnectedPagefindComponents(windowRef.PagefindComponents);
+
+  if (typeof windowRef.requestAnimationFrame === 'function') {
+    windowRef.requestAnimationFrame(prune);
+    return;
+  }
+
+  windowRef.setTimeout(prune, 0);
+};
+
+export const bindPagefindViewTransitionRefresh = (
+  documentRef: Document,
+  windowRef: PagefindWindow
+) => {
+  const refreshAfterTransition = () => schedulePrune(windowRef);
+  const refreshBeforeTriggerClick = (event: Event) => {
+    if (closestPagefindTrigger(event.target)) {
+      pruneDisconnectedPagefindComponents(windowRef.PagefindComponents);
+    }
+  };
+  const refreshBeforeShortcut = (event: KeyboardEvent) => {
+    if (isSearchShortcut(event, windowRef)) {
+      pruneDisconnectedPagefindComponents(windowRef.PagefindComponents);
+    }
+  };
+
+  documentRef.addEventListener('astro:page-load', refreshAfterTransition);
+  documentRef.addEventListener('astro:after-swap', refreshAfterTransition);
+  documentRef.addEventListener('click', refreshBeforeTriggerClick, true);
+  documentRef.addEventListener('keydown', refreshBeforeShortcut, true);
+  refreshAfterTransition();
+
+  return () => {
+    documentRef.removeEventListener('astro:page-load', refreshAfterTransition);
+    documentRef.removeEventListener('astro:after-swap', refreshAfterTransition);
+    documentRef.removeEventListener('click', refreshBeforeTriggerClick, true);
+    documentRef.removeEventListener('keydown', refreshBeforeShortcut, true);
+  };
+};
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  bindPagefindViewTransitionRefresh(document, window as PagefindWindow);
+}

--- a/tests/unit/scripts/pagefind-view-transitions.test.ts
+++ b/tests/unit/scripts/pagefind-view-transitions.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  bindPagefindViewTransitionRefresh,
+  pruneDisconnectedPagefindComponents,
+} from '../../../src/scripts/pagefind-view-transitions';
+
+const createPagefindState = () => {
+  const disconnectedModal = {
+    componentSubtype: 'modal',
+    isConnected: false,
+  };
+  const connectedModal = {
+    componentSubtype: 'modal',
+    isConnected: true,
+  };
+  const disconnectedTrigger = {
+    componentSubtype: 'modal-trigger',
+    isConnected: false,
+  };
+  const connectedTrigger = {
+    componentSubtype: 'modal-trigger',
+    isConnected: true,
+  };
+  const instance = {
+    components: [
+      disconnectedModal,
+      connectedModal,
+      disconnectedTrigger,
+      connectedTrigger,
+    ],
+    componentsByType: {
+      utility: [
+        disconnectedModal,
+        connectedModal,
+        disconnectedTrigger,
+        connectedTrigger,
+      ],
+    },
+    reconcileAria: vi.fn(),
+  };
+  const pagefindComponents = {
+    getInstanceManager: () => ({
+      getInstance: () => instance,
+    }),
+  };
+
+  return {
+    connectedModal,
+    connectedTrigger,
+    instance,
+    pagefindComponents,
+  };
+};
+
+const createTestDocument = () => {
+  const listeners = new Map<string, EventListener[]>();
+  const documentRef = {
+    addEventListener: vi.fn(
+      (type: string, listener: EventListenerOrEventListenerObject | null) => {
+        if (typeof listener === 'function') {
+          listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+        }
+      }
+    ),
+    removeEventListener: vi.fn(
+      (type: string, listener: EventListenerOrEventListenerObject | null) => {
+        if (typeof listener === 'function') {
+          listeners.set(
+            type,
+            (listeners.get(type) ?? []).filter(
+              (registered) => registered !== listener
+            )
+          );
+        }
+      }
+    ),
+  } as unknown as Document;
+
+  const dispatch = (type: string, event: Partial<Event> = {}) => {
+    listeners.get(type)?.forEach((listener) => {
+      listener(event as Event);
+    });
+  };
+
+  return { dispatch, documentRef };
+};
+
+describe('Pagefind view transition refresh', () => {
+  it('removes disconnected Pagefind utilities before the modal trigger resolves a dialog', () => {
+    const { connectedModal, connectedTrigger, instance, pagefindComponents } =
+      createPagefindState();
+
+    pruneDisconnectedPagefindComponents(pagefindComponents);
+
+    expect(instance.components).toEqual([connectedModal, connectedTrigger]);
+    expect(instance.componentsByType.utility).toEqual([
+      connectedModal,
+      connectedTrigger,
+    ]);
+    expect(instance.reconcileAria).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes Pagefind when Astro swaps pages and before trigger clicks', () => {
+    const { connectedModal, connectedTrigger, instance, pagefindComponents } =
+      createPagefindState();
+    const { dispatch, documentRef } = createTestDocument();
+    const windowRef = {
+      PagefindComponents: pagefindComponents,
+      navigator: { platform: 'MacIntel', userAgent: '' },
+      requestAnimationFrame: vi.fn((callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      }),
+      setTimeout: vi.fn(),
+    } as unknown as Window & {
+      PagefindComponents: typeof pagefindComponents;
+    };
+
+    const cleanup = bindPagefindViewTransitionRefresh(documentRef, windowRef);
+
+    dispatch('astro:after-swap');
+
+    expect(instance.components).toEqual([connectedModal, connectedTrigger]);
+
+    instance.components = [
+      { componentSubtype: 'modal', isConnected: false },
+      connectedModal,
+      connectedTrigger,
+    ];
+    instance.componentsByType.utility = [...instance.components];
+
+    dispatch('click', {
+      target: {
+        closest: (selector: string) =>
+          selector === 'pagefind-modal-trigger' ? {} : null,
+      } as unknown as EventTarget,
+    });
+
+    expect(instance.components).toEqual([connectedModal, connectedTrigger]);
+
+    cleanup();
+  });
+});

--- a/tests/unit/search/pagefind.test.ts
+++ b/tests/unit/search/pagefind.test.ts
@@ -54,6 +54,9 @@ describe('Pagefind search integration', () => {
     expect(layout).toMatch(
       /<pagefind-modal\b[^>]*transition:persist[^>]*transition:animate="none"[^>]*>/s
     );
+    expect(layout).toContain(
+      "import '../scripts/pagefind-view-transitions';"
+    );
   });
 
   it('places Pagefind config before UI components so options are registered first', () => {


### PR DESCRIPTION
## Summary

- Add a small Pagefind view-transition refresh script that prunes disconnected Pagefind components from the internal registry after Astro ClientRouter swaps.
- Run the cleanup on `astro:page-load`, `astro:after-swap`, and immediately before search trigger click / `mod+k` activation.
- Add unit coverage for the stale registry behavior and record the Pagefind/Astro finding in Serena memory.

## Root Cause

Pagefind Component UI keeps disconnected custom elements in its `components` / `componentsByType` registry after Astro view transitions. After navigation, a search trigger can resolve a stale modal utility instead of the connected dialog, so the search dialog may not appear.

## Validation

- `npm run test`
- `npm run check`
- `npm run lint`
- `npm run build`
- Playwright smoke check against `astro preview`: `/portfolio/` -> `/portfolio/blog`, verified disconnected Pagefind utilities are `0` and the modal dialog opens.