### PR TITLE
[codex] Simplify blog admonition styling

### DIFF
--- a/src/pages/blog/[year]/[month]/[slug].astro
+++ b/src/pages/blog/[year]/[month]/[slug].astro
@@ -433,34 +433,31 @@ const heroClass = heroImage
   }
 
   .content-wrapper :global(.admonition) {
-    --admonition-color: #0969da;
+    --admonition-color: var(--text-accent);
     display: grid;
     grid-template-columns: 1fr;
     row-gap: var(--space-xs);
-    padding: var(--space-md);
-    border-radius: var(--radius-md);
-    border: 1px solid var(--glass-border);
-    border-left: 3px solid var(--admonition-color);
-    background: color-mix(
-      in srgb,
-      var(--bento-card-bg) 92%,
-      var(--admonition-color) 8%
-    );
+    padding: 0 0 0 var(--space-md);
+    border-left: 2px solid var(--admonition-color);
+    background: transparent;
     margin: var(--space-lg) 0;
     color: var(--text-secondary);
-    box-shadow: var(--shadow-sm);
+    box-shadow: none;
   }
 
-  .content-wrapper :global(.admonition)::after {
+  .content-wrapper :global(.admonition)::before {
     content: attr(data-label);
-    color: var(--admonition-color);
-    font-weight: 700;
+    display: block;
+    margin-bottom: var(--space-xs);
+    color: color-mix(
+      in srgb,
+      var(--admonition-color) 78%,
+      var(--text-primary) 22%
+    );
+    font-weight: 600;
     font-size: var(--font-size-xs);
-    letter-spacing: 0.08em;
-    line-height: 1.2;
-    text-transform: uppercase;
+    line-height: 1.35;
     grid-column: 1;
-    grid-row: 1;
   }
 
   .content-wrapper :global(.admonition p),
@@ -472,23 +469,23 @@ const heroClass = heroImage
   }
 
   .content-wrapper :global(.admonition-note) {
-    --admonition-color: #58a6ff;
+    --admonition-color: #5e6ad2;
   }
 
   .content-wrapper :global(.admonition-tip) {
-    --admonition-color: #3fb950;
+    --admonition-color: #2f7d4f;
   }
 
   .content-wrapper :global(.admonition-important) {
-    --admonition-color: #a371f7;
+    --admonition-color: #8250df;
   }
 
   .content-wrapper :global(.admonition-warning) {
-    --admonition-color: #d29922;
+    --admonition-color: #9a6700;
   }
 
   .content-wrapper :global(.admonition-caution) {
-    --admonition-color: #f85149;
+    --admonition-color: #b42318;
   }
 
   .article-footer {

--- a/tests/unit/pages/blog.test.ts
+++ b/tests/unit/pages/blog.test.ts
@@ -267,7 +267,7 @@ describe('ブログ機能', () => {
     expect(detailPage).toMatch(/overflow-wrap:\s*anywhere/);
   });
 
-  it('ブログ詳細ページのadmonitionは控えめな単一カラムで表示する', () => {
+  it('ブログ詳細ページのadmonitionはカード化せず控えめな単一カラムで表示する', () => {
     const detailPage = load(
       '../../../src/pages/blog/[year]/[month]/[slug].astro'
     );
@@ -279,6 +279,27 @@ describe('ブログ機能', () => {
     expect(detailPage).not.toMatch(/mask:\s*var\(--admonition-icon-url\)/);
     expect(detailPage).toMatch(
       /\.content-wrapper\s+:global\(\.admonition p\),\s*\.content-wrapper\s+:global\(\.admonition ul\),\s*\.content-wrapper\s+:global\(\.admonition ol\)\s*\{[^}]*grid-column:\s*1/s
+    );
+    expect(detailPage).toMatch(
+      /\.content-wrapper\s+:global\(\.admonition\)\s*\{[^}]*border-left:\s*2px solid var\(--admonition-color\)[^}]*background:\s*transparent[^}]*box-shadow:\s*none/s
+    );
+    expect(detailPage).toMatch(
+      /\.content-wrapper\s+:global\(\.admonition\)::before\s*\{[^}]*content:\s*attr\(data-label\)[^}]*display:\s*block[^}]*margin-bottom:\s*var\(--space-xs\)/s
+    );
+    expect(detailPage).not.toMatch(
+      /\.content-wrapper\s+:global\(\.admonition\)\s*\{[^}]*border-radius:/s
+    );
+    expect(detailPage).not.toMatch(
+      /\.content-wrapper\s+:global\(\.admonition\)::before\s*\{[^}]*border-radius:/s
+    );
+    expect(detailPage).not.toMatch(
+      /\.content-wrapper\s+:global\(\.admonition\)::after\s*\{/s
+    );
+    expect(detailPage).not.toMatch(
+      /\.content-wrapper\s+:global\(\.admonition\)::(?:before|after)\s*\{[^}]*text-transform:\s*uppercase/s
+    );
+    expect(detailPage).not.toMatch(
+      /\.content-wrapper\s+:global\(\.admonition\)::(?:before|after)\s*\{[^}]*letter-spacing:\s*0\.08em/s
     );
   });
 


### PR DESCRIPTION
## Summary

- Simplify blog admonitions so they read as inline editorial notes rather than cards.
- Remove the tinted panel, border radius, outer border, shadow, uppercase label treatment, and pseudo-element rail.
- Keep the single-column structure, left accent line, label, and state colors for `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, and `CAUTION`.

## Why

The previous visual treatment made Markdown notes feel like standalone cards. This keeps the callout visible while making it calmer and closer to the surrounding article text.

## Validation

- `npm run test`
- `npm run check`
- `npm run lint`
- `npm run build`
- Playwright smoke screenshots for desktop/mobile admonitions