### PR TITLE
[codex] restore Pagefind modal after transitions

### DIFF
--- a/.serena/memories/pagefind_astro_transition_registry.md
+++ b/.serena/memories/pagefind_astro_transition_registry.md
@@ -1,5 +1,7 @@
 # Pagefind + Astro View Transitions
 
-Pagefind Component UI keeps disconnected custom elements in its internal `components` / `componentsByType` registry after Astro ClientRouter page swaps. If stale utilities remain, modal triggers can resolve an old modal and the search dialog may fail to appear after navigation.
+Pagefind Component UI does not deregister disconnected custom elements from its internal `components` / `componentsByType` registry after Astro ClientRouter page swaps. This project handles stale registry entries in `src/scripts/pagefind-view-transitions.ts` by pruning disconnected Pagefind components on `astro:page-load`, `astro:after-swap`, and immediately before search trigger click / mod+k activation.
 
-This project handles it in `src/scripts/pagefind-view-transitions.ts` by pruning disconnected Pagefind components on `astro:page-load`, `astro:after-swap`, and immediately before search trigger click / mod+k activation. Layout imports that module next to `portfolio-webmcp`.
+Do not persist `<pagefind-modal>` with Astro transitions. Pagefind's modal `connectedCallback` re-runs after Astro swaps and its `render()` treats the already-generated `<dialog class="pf-modal">` as custom child content, wrapping it in another generated `<dialog>`. After navigation this creates nested dialogs; the outer dialog opens and blurs the page, but its height is 0 so the visible search UI disappears. `src/layouts/Layout.astro` intentionally leaves `<pagefind-modal reset-on-close>` unpersisted so Astro recreates a fresh modal shell on each route.
+
+Persisting `<pagefind-config>` is still OK; the nav search trigger is inside the persisted navbar and is safe because its render path clears generated children instead of wrapping them.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -108,11 +108,7 @@ const navItems = baseNavItems.map((item) => {
       </div>
     </nav>
 
-    <pagefind-modal
-      reset-on-close
-      transition:persist
-      transition:animate="none"
-    ></pagefind-modal>
+    <pagefind-modal reset-on-close></pagefind-modal>
 
     <main>
       <slot />

--- a/tests/unit/search/pagefind.test.ts
+++ b/tests/unit/search/pagefind.test.ts
@@ -45,18 +45,24 @@ describe('Pagefind search integration', () => {
     );
   });
 
-  it('keeps Pagefind modal utilities alive across Astro view transitions', () => {
+  it('keeps Pagefind configuration stable across Astro view transitions', () => {
     const layout = readSource('src/layouts/Layout.astro');
 
     expect(layout).toMatch(
       /<pagefind-config\b[^>]*transition:persist[^>]*transition:animate="none"[^>]*>/s
     );
-    expect(layout).toMatch(
-      /<pagefind-modal\b[^>]*transition:persist[^>]*transition:animate="none"[^>]*>/s
-    );
     expect(layout).toContain(
       "import '../scripts/pagefind-view-transitions';"
     );
+  });
+
+  it('recreates the Pagefind modal shell instead of persisting generated dialog markup', () => {
+    const layout = readSource('src/layouts/Layout.astro');
+
+    const modalTag = layout.match(/<pagefind-modal(?:\s|>)[^>]*>/s)?.[0];
+
+    expect(modalTag).toBeDefined();
+    expect(modalTag).not.toContain('transition:persist');
   });
 
   it('places Pagefind config before UI components so options are registered first', () => {


### PR DESCRIPTION
## Summary

- Stop persisting the Pagefind modal custom element across Astro ClientRouter transitions.
- Keep Pagefind configuration persistence and the existing stale registry pruning script in place.
- Add a regression test that asserts the modal shell is recreated instead of carrying generated dialog markup across routes.
- Update the Serena project memory with the root cause and expected integration behavior.

## Root Cause

Pagefind re-runs the modal custom element initialization after Astro swaps. When `<pagefind-modal>` was persisted, its generated `<dialog class="pf-modal">` stayed inside the element. Pagefind then treated that existing dialog as custom child content and wrapped it in another generated dialog. After navigation, the outer dialog opened and blurred the page, but the nested content had zero height, so the search UI was invisible.

## Impact

Search opens normally after client-side navigation. The backdrop still appears, and the dialog content remains visible with the input focused.

## Validation

- `npm run test -- tests/unit/scripts/pagefind-view-transitions.test.ts tests/unit/search/pagefind.test.ts`
- `npm run test`
- `npm run check`
- `npm run lint`
- `npm run build`
- Playwright smoke check after `/portfolio/` -> `/portfolio/projects` navigation: one open dialog, non-zero height, focused search input.