### PR TITLE
[codex] harden Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -36,16 +36,15 @@ jobs:
   build:
     needs: test
     runs-on: ubuntu-latest
-    environment: github-pages
     env:
-      PUBLIC_EMAIL: ${{ secrets.PUBLIC_EMAIL }}
-      PUBLIC_GITHUB_URL: ${{ secrets.PUBLIC_GITHUB_URL }}
+      PUBLIC_EMAIL: ${{ vars.PUBLIC_EMAIL }}
+      PUBLIC_GITHUB_URL: ${{ vars.PUBLIC_GITHUB_URL }}
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install, build, and upload your site
-        uses: withastro/action@v2
+        uses: withastro/action@v6
         with:
           path: . # The root location of your Astro project inside the repository. (optional)
           node-version: 22 # Astro 6 requires Node.js 22.12.0 or newer.

--- a/tests/unit/workflows/deploy-workflow.test.ts
+++ b/tests/unit/workflows/deploy-workflow.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const workflowPath = fileURLToPath(
+  new URL('../../../.github/workflows/deploy.yml', import.meta.url)
+);
+const workflow = readFileSync(workflowPath, 'utf8');
+
+const getJobBlock = (jobName: string) => {
+  const marker = `  ${jobName}:\n`;
+  const start = workflow.indexOf(marker);
+  if (start === -1) {
+    throw new Error(`Missing ${jobName} job`);
+  }
+
+  const rest = workflow.slice(start + marker.length);
+  const nextJob = rest.search(/\n {2}[a-zA-Z0-9_-]+:\n/);
+  return nextJob === -1 ? rest : rest.slice(0, nextJob);
+};
+
+describe('Deploy workflow hardening', () => {
+  it('uses Node 24-compatible major versions for GitHub Actions', () => {
+    expect(workflow).toContain('uses: actions/checkout@v7');
+    expect(workflow).toContain('uses: actions/setup-node@v6');
+    expect(workflow).toContain('uses: withastro/action@v6');
+    expect(workflow).toContain('uses: actions/deploy-pages@v5');
+  });
+
+  it('keeps only the deploy job attached to the github-pages environment', () => {
+    expect(getJobBlock('build')).not.toContain('environment: github-pages');
+    expect(getJobBlock('deploy')).toContain('name: github-pages');
+  });
+
+  it('reads public build values from repository variables instead of environment secrets', () => {
+    expect(workflow).toContain('PUBLIC_EMAIL: ${{ vars.PUBLIC_EMAIL }}');
+    expect(workflow).toContain(
+      'PUBLIC_GITHUB_URL: ${{ vars.PUBLIC_GITHUB_URL }}'
+    );
+    expect(workflow).not.toContain('secrets.PUBLIC_EMAIL');
+    expect(workflow).not.toContain('secrets.PUBLIC_GITHUB_URL');
+  });
+});


### PR DESCRIPTION
## Summary
- move public build-time values from `github-pages` environment secrets to repository variables in the deploy workflow
- remove the `github-pages` environment from the build job so only the deploy job creates a Pages environment deployment
- update GitHub Actions to Node 24-compatible major versions: `checkout@v7`, `setup-node@v6`, `withastro/action@v6`, and keep `deploy-pages@v5`
- add a focused Vitest regression test for the Pages workflow shape

## Repository settings
- created repository variables `PUBLIC_EMAIL` and `PUBLIC_GITHUB_URL` from the currently published public values
- existing `github-pages` environment secrets were left in place but are no longer referenced by the workflow

## Validation
- npm test -- tests/unit/workflows/deploy-workflow.test.ts
- npm test -- --run
- npx prettier --check .github/workflows/deploy.yml tests/unit/workflows/deploy-workflow.test.ts
- npm run lint
- npm run check
- npm run build
- git diff --check