### PR TITLE
[codex] speed up playwright visual runner

### DIFF
--- a/.serena/memories/playwright_visual_runner_performance.md
+++ b/.serena/memories/playwright_visual_runner_performance.md
@@ -1,0 +1,7 @@
+# Playwright visual runner performance
+
+In this WSL environment, unused loopback ports such as `127.0.0.1:4324` time out instead of immediately returning `ECONNREFUSED`. Playwright's `webServer.url` availability check performs an HTTP GET before starting the configured server and does not set a short socket timeout, causing `npm run test:visual` to spend ~2m35s before tests start.
+
+Mitigation implemented: `npm run test:visual` runs `scripts/run-playwright-visual.mjs`, which starts Astro dev server on `127.0.0.1:4324`, waits for Astro readiness and a short-timeout HTTP 200, then runs Playwright with `PLAYWRIGHT_EXTERNAL_WEB_SERVER=1`. `playwright.config.ts` skips `webServer` when that env var is set.
+
+Observed after change: `/usr/bin/time -v npm run test:visual -- --reporter=line` completed in ~13.9s, with Playwright reporting `14 passed (4.8s)`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview",
     "preview:search": "npm run build && astro preview",
     "test": "vitest",
-    "test:visual": "playwright test",
+    "test:visual": "node scripts/run-playwright-visual.mjs",
     "check": "astro check && tsc",
     "lint": "eslint .",
     "format": "prettier --write ."

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const usesExternalWebServer =
+  process.env.PLAYWRIGHT_EXTERNAL_WEB_SERVER === '1';
+
 export default defineConfig({
   testDir: './tests/visual',
   timeout: 30_000,
@@ -11,12 +14,14 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
-  webServer: {
-    command: 'npm run dev -- --host 127.0.0.1 --port 4324 --strictPort',
-    url: 'http://127.0.0.1:4324/portfolio/',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-  },
+  webServer: usesExternalWebServer
+    ? undefined
+    : {
+        command: 'npm run dev -- --host 127.0.0.1 --port 4324 --strictPort',
+        url: 'http://127.0.0.1:4324/portfolio/',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
   projects: [
     {
       name: 'desktop',

--- a/scripts/run-playwright-visual.mjs
+++ b/scripts/run-playwright-visual.mjs
@@ -35,6 +35,7 @@ function startAstroDevServer() {
       cwd: rootDir,
       detached: !isWindows,
       env: process.env,
+      shell: isWindows,
       stdio: ['ignore', 'pipe', 'pipe'],
     }
   );
@@ -138,6 +139,7 @@ function runPlaywright(args) {
         ...process.env,
         PLAYWRIGHT_EXTERNAL_WEB_SERVER: '1',
       },
+      shell: isWindows,
       stdio: 'inherit',
     });
 

--- a/scripts/run-playwright-visual.mjs
+++ b/scripts/run-playwright-visual.mjs
@@ -30,7 +30,7 @@ function appendServerOutput(data) {
 function startAstroDevServer() {
   const child = spawn(
     localBin('astro'),
-    ['dev', '--host', host, '--port', String(port), '--strictPort'],
+    ['dev', '--host', host, '--port', String(port)],
     {
       cwd: rootDir,
       detached: !isWindows,
@@ -66,7 +66,7 @@ function waitForAstroReady(child) {
 
     const onData = () => {
       if (
-        /astro\s+v[\d.]+ ready in|Local\s+http:\/\/127\.0\.0\.1:4324\/portfolio/.test(
+        /Local\s+http:\/\/127\.0\.0\.1:4324\/portfolio\/?(?:\s|$)/.test(
           serverOutput
         )
       ) {

--- a/scripts/run-playwright-visual.mjs
+++ b/scripts/run-playwright-visual.mjs
@@ -233,7 +233,7 @@ function printServerOutput() {
 
 async function main() {
   try {
-    if (await requestURL(baseURL, 1_000)) {
+    if (!process.env.CI && (await requestURL(baseURL, 1_000))) {
       console.log(`Reusing Astro dev server at ${baseURL}`);
       const exitCode = await runPlaywright(process.argv.slice(2));
       process.exitCode = exitCode;

--- a/scripts/run-playwright-visual.mjs
+++ b/scripts/run-playwright-visual.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { request } from 'node:http';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = fileURLToPath(new URL('..', import.meta.url));
+const host = '127.0.0.1';
+const port = 4324;
+const baseURL = `http://${host}:${port}/portfolio/`;
+const isWindows = process.platform === 'win32';
+
+let serverOutput = '';
+let devServer;
+
+function localBin(name) {
+  const suffix = isWindows ? '.cmd' : '';
+  return fileURLToPath(
+    new URL(`../node_modules/.bin/${name}${suffix}`, import.meta.url)
+  );
+}
+
+function appendServerOutput(data) {
+  serverOutput += data.toString();
+  if (serverOutput.length > 20_000) {
+    serverOutput = serverOutput.slice(-20_000);
+  }
+}
+
+function startAstroDevServer() {
+  const child = spawn(
+    localBin('astro'),
+    ['dev', '--host', host, '--port', String(port), '--strictPort'],
+    {
+      cwd: rootDir,
+      detached: !isWindows,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+
+  child.stdout.on('data', appendServerOutput);
+  child.stderr.on('data', appendServerOutput);
+  return child;
+}
+
+function waitForAstroReady(child) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out waiting for Astro dev server readiness.'));
+    }, 30_000);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.stdout.off('data', onData);
+      child.stderr.off('data', onData);
+      child.off('exit', onExit);
+      child.off('error', onError);
+    };
+
+    const finish = () => {
+      cleanup();
+      resolve();
+    };
+
+    const onData = () => {
+      if (
+        /astro\s+v[\d.]+ ready in|Local\s+http:\/\/127\.0\.0\.1:4324\/portfolio/.test(
+          serverOutput
+        )
+      ) {
+        finish();
+      }
+    };
+
+    const onExit = (code, signal) => {
+      cleanup();
+      reject(
+        new Error(
+          `Astro dev server exited before readiness. code=${code ?? 'null'} signal=${signal ?? 'null'}`
+        )
+      );
+    };
+
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    child.once('exit', onExit);
+    child.once('error', onError);
+  });
+}
+
+function requestURL(url, timeoutMs) {
+  return new Promise((resolve) => {
+    const req = request(
+      url,
+      {
+        headers: { Accept: '*/*' },
+        timeout: timeoutMs,
+      },
+      (res) => {
+        res.resume();
+        resolve((res.statusCode ?? 0) >= 200 && (res.statusCode ?? 0) < 400);
+      }
+    );
+
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.on('error', () => resolve(false));
+    req.end();
+  });
+}
+
+async function waitForHTTP(url) {
+  const deadline = Date.now() + 10_000;
+
+  while (Date.now() < deadline) {
+    if (await requestURL(url, 1_000)) {
+      return;
+    }
+    await delay(100);
+  }
+
+  throw new Error(`Timed out waiting for ${url} to respond.`);
+}
+
+function runPlaywright(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(localBin('playwright'), ['test', ...args], {
+      cwd: rootDir,
+      env: {
+        ...process.env,
+        PLAYWRIGHT_EXTERNAL_WEB_SERVER: '1',
+      },
+      stdio: 'inherit',
+    });
+
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (signal === 'SIGINT') {
+        resolve(130);
+        return;
+      }
+      if (signal) {
+        resolve(1);
+        return;
+      }
+      resolve(code ?? 1);
+    });
+  });
+}
+
+async function stopProcess(child) {
+  if (!child?.pid || child.exitCode !== null) {
+    return;
+  }
+
+  const exited = new Promise((resolve) => child.once('exit', resolve));
+
+  try {
+    if (isWindows) {
+      child.kill('SIGTERM');
+    } else {
+      process.kill(-child.pid, 'SIGTERM');
+    }
+  } catch (error) {
+    if (error.code !== 'ESRCH') {
+      throw error;
+    }
+  }
+
+  await Promise.race([exited, delay(5_000)]);
+
+  if (child.exitCode === null) {
+    try {
+      if (isWindows) {
+        child.kill('SIGKILL');
+      } else {
+        process.kill(-child.pid, 'SIGKILL');
+      }
+    } catch (error) {
+      if (error.code !== 'ESRCH') {
+        throw error;
+      }
+    }
+  }
+}
+
+function printServerOutput() {
+  if (serverOutput.trim()) {
+    console.error('\nAstro dev server output:\n');
+    console.error(serverOutput.trim());
+  }
+}
+
+async function main() {
+  devServer = startAstroDevServer();
+
+  try {
+    await waitForAstroReady(devServer);
+    await waitForHTTP(baseURL);
+    console.log(`Astro dev server ready at ${baseURL}`);
+    const exitCode = await runPlaywright(process.argv.slice(2));
+    process.exitCode = exitCode;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    printServerOutput();
+    process.exitCode = 1;
+  } finally {
+    await stopProcess(devServer);
+  }
+}
+
+process.once('SIGINT', async () => {
+  await stopProcess(devServer);
+  process.exit(130);
+});
+
+process.once('SIGTERM', async () => {
+  await stopProcess(devServer);
+  process.exit(143);
+});
+
+await main();

--- a/scripts/run-playwright-visual.mjs
+++ b/scripts/run-playwright-visual.mjs
@@ -158,6 +158,18 @@ function runPlaywright(args) {
   });
 }
 
+function killWindowsProcessTree(pid) {
+  return new Promise((resolve, reject) => {
+    const killer = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+
+    killer.once('error', reject);
+    killer.once('exit', () => resolve());
+  });
+}
+
 async function stopProcess(child) {
   if (!child?.pid || child.exitCode !== null) {
     return;
@@ -167,7 +179,7 @@ async function stopProcess(child) {
 
   try {
     if (isWindows) {
-      child.kill('SIGTERM');
+      await killWindowsProcessTree(child.pid);
     } else {
       process.kill(-child.pid, 'SIGTERM');
     }
@@ -182,7 +194,7 @@ async function stopProcess(child) {
   if (child.exitCode === null) {
     try {
       if (isWindows) {
-        child.kill('SIGKILL');
+        await killWindowsProcessTree(child.pid);
       } else {
         process.kill(-child.pid, 'SIGKILL');
       }

--- a/scripts/run-playwright-visual.mjs
+++ b/scripts/run-playwright-visual.mjs
@@ -9,6 +9,10 @@ const host = '127.0.0.1';
 const port = 4324;
 const baseURL = `http://${host}:${port}/portfolio/`;
 const isWindows = process.platform === 'win32';
+const targetLocalURLPattern =
+  /Local\s+http:\/\/127\.0\.0\.1:4324\/portfolio\/?(?:\s|$)/;
+const anyLocalURLPattern =
+  /Local\s+(http:\/\/127\.0\.0\.1:\d+\/portfolio\/?)(?:\s|$)/;
 
 let serverOutput = '';
 let devServer;
@@ -25,6 +29,10 @@ function appendServerOutput(data) {
   if (serverOutput.length > 20_000) {
     serverOutput = serverOutput.slice(-20_000);
   }
+}
+
+function normalizeURL(url) {
+  return url.endsWith('/') ? url : `${url}/`;
 }
 
 function startAstroDevServer() {
@@ -64,19 +72,30 @@ function waitForAstroReady(child) {
       resolve();
     };
 
+    const fail = (error) => {
+      cleanup();
+      reject(error);
+    };
+
     const onData = () => {
-      if (
-        /Local\s+http:\/\/127\.0\.0\.1:4324\/portfolio\/?(?:\s|$)/.test(
-          serverOutput
-        )
-      ) {
+      if (targetLocalURLPattern.test(serverOutput)) {
         finish();
+        return;
+      }
+
+      const localURLMatch = serverOutput.match(anyLocalURLPattern);
+      if (localURLMatch) {
+        const reportedURL = normalizeURL(localURLMatch[1]);
+        fail(
+          new Error(
+            `Astro dev server started at ${reportedURL} instead of ${baseURL}. Is port ${port} already in use?`
+          )
+        );
       }
     };
 
     const onExit = (code, signal) => {
-      cleanup();
-      reject(
+      fail(
         new Error(
           `Astro dev server exited before readiness. code=${code ?? 'null'} signal=${signal ?? 'null'}`
         )
@@ -84,8 +103,7 @@ function waitForAstroReady(child) {
     };
 
     const onError = (error) => {
-      cleanup();
-      reject(error);
+      fail(error);
     };
 
     child.stdout.on('data', onData);
@@ -214,9 +232,15 @@ function printServerOutput() {
 }
 
 async function main() {
-  devServer = startAstroDevServer();
-
   try {
+    if (await requestURL(baseURL, 1_000)) {
+      console.log(`Reusing Astro dev server at ${baseURL}`);
+      const exitCode = await runPlaywright(process.argv.slice(2));
+      process.exitCode = exitCode;
+      return;
+    }
+
+    devServer = startAstroDevServer();
     await waitForAstroReady(devServer);
     await waitForHTTP(baseURL);
     console.log(`Astro dev server ready at ${baseURL}`);

--- a/tests/unit/config/playwright-visual-runner.test.ts
+++ b/tests/unit/config/playwright-visual-runner.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const packageJson = JSON.parse(
+  readFileSync(new URL('../../../package.json', import.meta.url), 'utf-8')
+) as {
+  scripts: Record<string, string>;
+};
+
+const playwrightConfig = readFileSync(
+  new URL('../../../playwright.config.ts', import.meta.url),
+  'utf-8'
+);
+
+describe('Playwright visual test runner', () => {
+  it('uses a wrapper that starts Astro before Playwright checks availability', () => {
+    expect(packageJson.scripts['test:visual']).toBe(
+      'node scripts/run-playwright-visual.mjs'
+    );
+  });
+
+  it('can skip Playwright webServer when the wrapper provides the server', () => {
+    expect(playwrightConfig).toContain('PLAYWRIGHT_EXTERNAL_WEB_SERVER');
+    expect(playwrightConfig).toMatch(
+      /webServer:\s*usesExternalWebServer\s*\?\s*undefined\s*:/s
+    );
+  });
+});

--- a/tests/unit/config/playwright-visual-runner.test.ts
+++ b/tests/unit/config/playwright-visual-runner.test.ts
@@ -57,4 +57,17 @@ describe('Playwright visual test runner', () => {
     expect(visualRunnerScript).toContain("'/t'");
     expect(visualRunnerScript).toContain("'/f'");
   });
+
+  it('reuses a healthy visual server before starting Astro', () => {
+    expect(visualRunnerScript).toMatch(
+      /if\s*\(\s*await requestURL\(baseURL,\s*1_000\)\s*\)[\s\S]*Reusing Astro dev server[\s\S]*runPlaywright\(process\.argv\.slice\(2\)\)[\s\S]*return[\s\S]*devServer = startAstroDevServer\(\)/
+    );
+  });
+
+  it('fails fast when Astro reports a different local URL', () => {
+    expect(visualRunnerScript).toContain(
+      'Astro dev server started at ${reportedURL} instead of ${baseURL}'
+    );
+    expect(visualRunnerScript).toContain('Is port ${port} already in use?');
+  });
 });

--- a/tests/unit/config/playwright-visual-runner.test.ts
+++ b/tests/unit/config/playwright-visual-runner.test.ts
@@ -13,6 +13,11 @@ const playwrightConfig = readFileSync(
   'utf-8'
 );
 
+const visualRunnerScript = readFileSync(
+  new URL('../../../scripts/run-playwright-visual.mjs', import.meta.url),
+  'utf-8'
+);
+
 describe('Playwright visual test runner', () => {
   it('uses a wrapper that starts Astro before Playwright checks availability', () => {
     expect(packageJson.scripts['test:visual']).toBe(
@@ -24,6 +29,15 @@ describe('Playwright visual test runner', () => {
     expect(playwrightConfig).toContain('PLAYWRIGHT_EXTERNAL_WEB_SERVER');
     expect(playwrightConfig).toMatch(
       /webServer:\s*usesExternalWebServer\s*\?\s*undefined\s*:/s
+    );
+  });
+
+  it('launches npm command shims through a shell on Windows', () => {
+    expect(visualRunnerScript).toMatch(
+      /spawn\(\s*localBin\('astro'\)[\s\S]*shell:\s*isWindows/
+    );
+    expect(visualRunnerScript).toMatch(
+      /spawn\(\s*localBin\('playwright'\)[\s\S]*shell:\s*isWindows/
     );
   });
 });

--- a/tests/unit/config/playwright-visual-runner.test.ts
+++ b/tests/unit/config/playwright-visual-runner.test.ts
@@ -60,7 +60,13 @@ describe('Playwright visual test runner', () => {
 
   it('reuses a healthy visual server before starting Astro', () => {
     expect(visualRunnerScript).toMatch(
-      /if\s*\(\s*await requestURL\(baseURL,\s*1_000\)\s*\)[\s\S]*Reusing Astro dev server[\s\S]*runPlaywright\(process\.argv\.slice\(2\)\)[\s\S]*return[\s\S]*devServer = startAstroDevServer\(\)/
+      /if\s*\(\s*!process\.env\.CI\s*&&\s*\(?\s*await requestURL\(baseURL,\s*1_000\)\s*\)?\s*\)[\s\S]*Reusing Astro dev server[\s\S]*runPlaywright\(process\.argv\.slice\(2\)\)[\s\S]*return[\s\S]*devServer = startAstroDevServer\(\)/
+    );
+  });
+
+  it('does not reuse an existing visual server in CI', () => {
+    expect(visualRunnerScript).toMatch(
+      /if\s*\(\s*!process\.env\.CI\s*&&\s*\(?\s*await requestURL\(baseURL,\s*1_000\)\s*\)?\s*\)/
     );
   });
 

--- a/tests/unit/config/playwright-visual-runner.test.ts
+++ b/tests/unit/config/playwright-visual-runner.test.ts
@@ -40,4 +40,14 @@ describe('Playwright visual test runner', () => {
       /spawn\(\s*localBin\('playwright'\)[\s\S]*shell:\s*isWindows/
     );
   });
+
+  it('requires Astro to report the exact tested URL before continuing', () => {
+    expect(visualRunnerScript).toContain(
+      'Local\\s+http:\\/\\/127\\.0\\.0\\.1:4324\\/portfolio'
+    );
+    expect(visualRunnerScript).not.toContain(
+      'astro\\s+v[\\d.]+ ready in|Local'
+    );
+    expect(visualRunnerScript).not.toContain("'--strictPort'");
+  });
 });

--- a/tests/unit/config/playwright-visual-runner.test.ts
+++ b/tests/unit/config/playwright-visual-runner.test.ts
@@ -50,4 +50,11 @@ describe('Playwright visual test runner', () => {
     );
     expect(visualRunnerScript).not.toContain("'--strictPort'");
   });
+
+  it('kills the Astro process tree on Windows', () => {
+    expect(visualRunnerScript).toContain("'taskkill'");
+    expect(visualRunnerScript).toContain("'/pid'");
+    expect(visualRunnerScript).toContain("'/t'");
+    expect(visualRunnerScript).toContain("'/f'");
+  });
 });


### PR DESCRIPTION
## Summary

- Replace `npm run test:visual` with a Node wrapper that starts Astro before launching Playwright.
- Allow `playwright.config.ts` to skip its `webServer` startup/check when the wrapper provides the server.
- Add a unit test that locks the wrapper script and external-server config path.
- Record the Playwright timing investigation in Serena project memory for future agents.

## Why

In this environment, unused loopback ports time out instead of immediately refusing connections. Playwright checks `webServer.url` before starting the configured server, and that availability check can stall for minutes before the visual tests begin.

The wrapper avoids that slow preflight path by starting Astro directly, waiting for readiness with a short HTTP timeout, then running Playwright against the already-running local server.

## Validation

- `npm run test -- --run`
- `npm run check`
- `npm run lint`
- `/usr/bin/time -v npm run test:visual -- --reporter=line`

Visual test result after the change: `14 passed (6.5s)`, wall clock `0:17.24`. Before the change, the same command took about `2:35.72`.